### PR TITLE
ENH: Change background color for dropdown list

### DIFF
--- a/probe_basic/probe_basic.qss
+++ b/probe_basic/probe_basic.qss
@@ -23,6 +23,11 @@ QComboBox[editable="true"]::drop-down {
     background: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgba(213, 218, 216, 255), stop:0.169312 rgba(82, 82, 83, 255), stop:0.328042 rgba(72, 70, 73, 255), stop:0.492063 rgba(78, 77, 79, 255), stop:0.703704 rgba(72, 70, 73, 255), stop:0.86 rgba(82, 82, 83, 255), stop:1 rgba(213, 218, 216, 255));
 }
 
+QComboBox QAbstractItemView {
+    background: rgba(82, 82, 83, 255);
+    border: 2px solid black;
+}
+
 QPushButton {
     font-family: "Bebas Kai";
     font-size: 15pt;


### PR DESCRIPTION
Problem:
- The background color for the drop down list and text color from the
  combobox were the same making it hard to read the text in the list.

Solution:
- Set the listview background to be the same as the mid-gradient of the
  combobox so the text is readable, and the listview style matches the
  combobox.

NB: See the Set Work Offsets popup for an example.