### PR TITLE
ENH: Allow WCS offset to be entered on main DRO panel

### DIFF
--- a/probe_basic/probe_basic.ui
+++ b/probe_basic/probe_basic.ui
@@ -224,7 +224,7 @@ bottom-margin: 0px;
            <enum>QTabWidget::South</enum>
           </property>
           <property name="currentIndex">
-           <number>0</number>
+           <number>4</number>
           </property>
           <widget class="QWidget" name="main_tab">
            <attribute name="title">
@@ -321,7 +321,7 @@ background-color: transparent;
                  <widget class="RecentFileComboBox" name="recentfilecombobox">
                   <property name="minimumSize">
                    <size>
-                    <width>148</width>
+                    <width>142</width>
                     <height>30</height>
                    </size>
                   </property>
@@ -27742,13 +27742,7 @@ QLabel[style=&quot;homing&quot;]{
                 </widget>
                </item>
                <item>
-                <widget class="DROWidget" name="drowidget_8">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
+                <widget class="DROLineEdit" name="dro_entry_main_x">
                  <property name="minimumSize">
                   <size>
                    <width>100</width>
@@ -27761,8 +27755,17 @@ QLabel[style=&quot;homing&quot;]{
                    <height>35</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <family>Bebas Kai</family>
+                   <pointsize>17</pointsize>
+                   <weight>50</weight>
+                   <italic>false</italic>
+                   <bold>false</bold>
+                  </font>
+                 </property>
                  <property name="styleSheet">
-                  <string notr="true">QLabel{
+                  <string notr="true">QLineEdit{
     border-style: transparant;
     border-color: rgb(235, 235, 235);
     border-width: 1px;
@@ -27775,9 +27778,6 @@ QLabel[style=&quot;homing&quot;]{
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                 <property name="referenceType" stdset="0">
-                  <enum>DROWidget::Relative</enum>
                  </property>
                 </widget>
                </item>
@@ -28020,13 +28020,7 @@ QLabel[style=&quot;homing&quot;]{
                 </widget>
                </item>
                <item>
-                <widget class="DROWidget" name="drowidget_9">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
+                <widget class="DROLineEdit" name="dro_entry_main_y">
                  <property name="minimumSize">
                   <size>
                    <width>100</width>
@@ -28039,8 +28033,17 @@ QLabel[style=&quot;homing&quot;]{
                    <height>35</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <family>Bebas Kai</family>
+                   <pointsize>17</pointsize>
+                   <weight>50</weight>
+                   <italic>false</italic>
+                   <bold>false</bold>
+                  </font>
+                 </property>
                  <property name="styleSheet">
-                  <string notr="true">QLabel{
+                  <string notr="true">QLineEdit{
     border-style: transparant;
     border-color: rgb(235, 235, 235);
     border-width: 1px;
@@ -28054,11 +28057,8 @@ QLabel[style=&quot;homing&quot;]{
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
-                 <property name="referenceType" stdset="0">
-                  <enum>DROWidget::Relative</enum>
-                 </property>
-                 <property name="axis" stdset="0">
-                  <enum>DROWidget::Y</enum>
+                 <property name="axisNumber" stdset="0">
+                  <number>1</number>
                  </property>
                 </widget>
                </item>
@@ -28298,13 +28298,7 @@ QLabel[style=&quot;homing&quot;]{
                 </widget>
                </item>
                <item>
-                <widget class="DROWidget" name="drowidget_10">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
+                <widget class="DROLineEdit" name="dro_entry_main_z">
                  <property name="minimumSize">
                   <size>
                    <width>100</width>
@@ -28317,8 +28311,17 @@ QLabel[style=&quot;homing&quot;]{
                    <height>35</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <family>Bebas Kai</family>
+                   <pointsize>17</pointsize>
+                   <weight>50</weight>
+                   <italic>false</italic>
+                   <bold>false</bold>
+                  </font>
+                 </property>
                  <property name="styleSheet">
-                  <string notr="true">QLabel{
+                  <string notr="true">QLineEdit{
     border-style: transparant;
     border-color: rgb(235, 235, 235);
     border-width: 1px;
@@ -28332,11 +28335,8 @@ QLabel[style=&quot;homing&quot;]{
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
-                 <property name="referenceType" stdset="0">
-                  <enum>DROWidget::Relative</enum>
-                 </property>
-                 <property name="axis" stdset="0">
-                  <enum>DROWidget::Z</enum>
+                 <property name="axisNumber" stdset="0">
+                  <number>2</number>
                  </property>
                 </widget>
                </item>
@@ -28578,13 +28578,7 @@ QLabel[style=&quot;homing&quot;]{
                 </widget>
                </item>
                <item>
-                <widget class="DROWidget" name="drowidget_11">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
+                <widget class="DROLineEdit" name="dro_entry_main_a">
                  <property name="minimumSize">
                   <size>
                    <width>100</width>
@@ -28597,8 +28591,17 @@ QLabel[style=&quot;homing&quot;]{
                    <height>35</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <family>Bebas Kai</family>
+                   <pointsize>17</pointsize>
+                   <weight>50</weight>
+                   <italic>false</italic>
+                   <bold>false</bold>
+                  </font>
+                 </property>
                  <property name="styleSheet">
-                  <string notr="true">QLabel{
+                  <string notr="true">QLineEdit{
     border-style: transparant;
     border-color: rgb(235, 235, 235);
     border-width: 1px;
@@ -28612,11 +28615,8 @@ QLabel[style=&quot;homing&quot;]{
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
-                 <property name="referenceType" stdset="0">
-                  <enum>DROWidget::Relative</enum>
-                 </property>
-                 <property name="axis" stdset="0">
-                  <enum>DROWidget::A</enum>
+                 <property name="axisNumber" stdset="0">
+                  <number>3</number>
                  </property>
                 </widget>
                </item>
@@ -28859,13 +28859,7 @@ QLabel[style=&quot;homing&quot;]{
                 </widget>
                </item>
                <item>
-                <widget class="DROWidget" name="drowidget_12">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
+                <widget class="DROLineEdit" name="dro_entry_main_b">
                  <property name="minimumSize">
                   <size>
                    <width>100</width>
@@ -28878,8 +28872,17 @@ QLabel[style=&quot;homing&quot;]{
                    <height>35</height>
                   </size>
                  </property>
+                 <property name="font">
+                  <font>
+                   <family>Bebas Kai</family>
+                   <pointsize>17</pointsize>
+                   <weight>50</weight>
+                   <italic>false</italic>
+                   <bold>false</bold>
+                  </font>
+                 </property>
                  <property name="styleSheet">
-                  <string notr="true">QLabel{
+                  <string notr="true">QLineEdit{
     border-style: transparant;
     border-color: rgb(235, 235, 235);
     border-width: 1px;
@@ -28893,11 +28896,8 @@ QLabel[style=&quot;homing&quot;]{
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
-                 <property name="referenceType" stdset="0">
-                  <enum>DROWidget::Relative</enum>
-                 </property>
-                 <property name="axis" stdset="0">
-                  <enum>DROWidget::B</enum>
+                 <property name="axisNumber" stdset="0">
+                  <number>4</number>
                  </property>
                 </widget>
                </item>
@@ -30725,7 +30725,7 @@ border-radius: 1px;
      <x>0</x>
      <y>0</y>
      <width>1918</width>
-     <height>27</height>
+     <height>26</height>
     </rect>
    </property>
    <property name="minimumSize">
@@ -30924,6 +30924,11 @@ font: 11pt bebas kai;
    <header>qtpyvcp.widgets.input_widgets.jog_increment</header>
   </customwidget>
   <customwidget>
+   <class>DynATC</class>
+   <extends>QQuickWidget</extends>
+   <header>widgets.atc_widget.atc</header>
+  </customwidget>
+  <customwidget>
    <class>FileSystemTable</class>
    <extends>QTableView</extends>
    <header>qtpyvcp.widgets.input_widgets.file_system</header>
@@ -30949,6 +30954,11 @@ font: 11pt bebas kai;
    <header>qtpyvcp.widgets.input_widgets.file_system</header>
   </customwidget>
   <customwidget>
+   <class>DROLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qtpyvcp.widgets.input_widgets.dro_line_edit</header>
+  </customwidget>
+  <customwidget>
    <class>ProbeSim</class>
    <extends>QWidget</extends>
    <header>qtpyvcp.widgets.input_widgets.probesim_widget</header>
@@ -30962,11 +30972,6 @@ font: 11pt bebas kai;
    <class>StatusLabel</class>
    <extends>QLabel</extends>
    <header>qtpyvcp.widgets.display_widgets.status_label</header>
-  </customwidget>
-  <customwidget>
-   <class>DynATC</class>
-   <extends>QQuickWidget</extends>
-   <header>qtpyvcp.widgets.display_widgets.atc_widget.atc</header>
   </customwidget>
   <customwidget>
    <class>VCPStackedWidget</class>
@@ -32283,16 +32288,16 @@ font: 11pt bebas kai;
   </property>
  </designerdata>
  <buttongroups>
-  <buttongroup name="customwcsbtnGroup"/>
-  <buttongroup name="fileviewerbtnGroup"/>
-  <buttongroup name="plotviewGroup"/>
-  <buttongroup name="probemodeGroup"/>
-  <buttongroup name="proberoutinebtnGroup"/>
-  <buttongroup name="xycalbtnGroup"/>
-  <buttongroup name="probepagewcsbtnGroup"/>
   <buttongroup name="mainorthoperspbtnGroup"/>
+  <buttongroup name="xycalbtnGroup"/>
   <buttongroup name="probehelpGroup"/>
-  <buttongroup name="probetabGroup"/>
+  <buttongroup name="proberoutinebtnGroup"/>
+  <buttongroup name="plotviewGroup"/>
+  <buttongroup name="fileviewerbtnGroup"/>
   <buttongroup name="plotorthoperspbtnGroup"/>
+  <buttongroup name="customwcsbtnGroup"/>
+  <buttongroup name="probetabGroup"/>
+  <buttongroup name="probemodeGroup"/>
+  <buttongroup name="probepagewcsbtnGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Problem:
- There was no direct way to set the WCS offset directly. For instance
  to take into account an edge finder radius, or similar location
  tooling.

- The main panel DRO did not support arithmetic expressions.

Solution:
- Replace the DROWidget with a DROLineEdit so that the WCS offsets can
  be entered into the DRO read out directly.

- Take advantage of the support for arithmetic expressions in the DRO
  by using the DROLineEdit from the latest qtpyvcp updates.

https://github.com/kcjengr/qtpyvcp/blob/master/qtpyvcp/widgets/base_widgets/eval_line_edit.py