### PR TITLE
subroutines: fix rotation probing with pre-existing rotation offset

### DIFF
--- a/configs/probe_basic_lathe/subroutines/probe_corner_x_minus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_x_minus_edge_angle.ngc
@@ -34,6 +34,7 @@ o<probe_corner_x_minus_edge_angle> sub
 
   #<workspace_x> = #[5201 + [20 * #5220]]
   #<workspace_y> = #[5202 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
   (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -156,7 +157,7 @@ o<probe_corner_x_minus_edge_angle> sub
   (probe mode rules for WCO,Rotation and probe position measuring only)
   o<160> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle> + #<workspace_r>]
     o<probe_corner_x_minus_edge_angle> return
   o<160> endif
 

--- a/configs/probe_basic_lathe/subroutines/probe_corner_x_plus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_x_plus_edge_angle.ngc
@@ -34,6 +34,7 @@ o<probe_corner_x_plus_edge_angle> sub
 
   #<workspace_x> = #[5201 + [20 * #5220]]
   #<workspace_y> = #[5202 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
   (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -156,7 +157,7 @@ o<probe_corner_x_plus_edge_angle> sub
   (probe mode rules for WCO,Rotation and probe position measuring only)
   o<160> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle> + #<workspace_r>]
     o<probe_corner_x_plus_edge_angle> return
   o<160> endif
 

--- a/configs/probe_basic_lathe/subroutines/probe_corner_y_minus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_y_minus_edge_angle.ngc
@@ -34,6 +34,7 @@ o<probe_corner_y_minus_edge_angle> sub
 
   #<workspace_x> = #[5201 + [20 * #5220]]
   #<workspace_y> = #[5202 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
   (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -156,7 +157,7 @@ o<probe_corner_y_minus_edge_angle> sub
   (probe mode rules for WCO,Rotation and probe position measuring only)
   o<160> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle> + #<workspace_r>]
     o<probe_corner_y_minus_edge_angle> return
   o<160> endif
 

--- a/configs/probe_basic_lathe/subroutines/probe_corner_y_plus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_y_plus_edge_angle.ngc
@@ -34,6 +34,7 @@ o<probe_corner_y_plus_edge_angle> sub
 
   #<workspace_x> = #[5201 + [20 * #5220]]
   #<workspace_y> = #[5202 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
   (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -156,7 +157,7 @@ o<probe_corner_y_plus_edge_angle> sub
   (probe mode rules for WCO,Rotation and probe position measuring only)
   o<160> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<c1x> + #<workspace_x>] Y[#<c1y> + #<workspace_y>] R[#<edge_angle> + #<workspace_r>]
     o<probe_corner_y_plus_edge_angle> return
   o<160> endif
 

--- a/configs/probe_basic_lathe/subroutines/probe_top_back_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_back_edge_angle.ngc
@@ -33,6 +33,7 @@ o<probe_top_back_edge_angle> sub
   G92.1
 
   #<workspace_y> = #[5202 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
   (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -115,7 +116,7 @@ o<probe_top_back_edge_angle> sub
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o<150> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<x_start_position>] Y[#<y_minus_zero_edge_start> + #<workspace_y>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<x_start_position>] Y[#<y_minus_zero_edge_start> + #<workspace_y>] R[#<edge_angle> + #<workspace_r>]
     o<probe_top_back_edge_angle> return
   o<150> endif
 

--- a/configs/probe_basic_lathe/subroutines/probe_top_front_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_front_edge_angle.ngc
@@ -33,6 +33,7 @@ o<probe_top_front_edge_angle> sub
   G92.1
 
   #<workspace_y> = #[5202 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
     (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -115,7 +116,7 @@ o<probe_top_front_edge_angle> sub
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o<150> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<x_start_position>] Y[#<y_plus_zero_edge_start> + #<workspace_y>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<x_start_position>] Y[#<y_plus_zero_edge_start> + #<workspace_y>] R[#<edge_angle> + #<workspace_r>]
     o<probe_top_front_edge_angle> return
   o<150> endif
 

--- a/configs/probe_basic_lathe/subroutines/probe_top_left_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_left_edge_angle.ngc
@@ -33,6 +33,7 @@ o<probe_top_left_edge_angle> sub
   G92.1
 
   #<workspace_x> = #[5201 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
   (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -115,7 +116,7 @@ o<probe_top_left_edge_angle> sub
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o<150> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<x_plus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<x_plus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle> + #<workspace_r>]
     o<probe_top_left_edge_angle> return
   o<150> endif
 

--- a/configs/probe_basic_lathe/subroutines/probe_top_right_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_right_edge_angle.ngc
@@ -33,6 +33,7 @@ o<Probe_top_right_edge_angle> sub
   G92.1
 
   #<workspace_x> = #[5201 + [20 * #5220]]
+  #<workspace_r> = #[5210 + [20 * #5220]]
 
   (Probe Tool Safety Check)
   o<110> if [#5400 NE #<probe_tool_number>]
@@ -115,7 +116,7 @@ o<Probe_top_right_edge_angle> sub
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o<150> if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
     (Record Zero in selected axes and WCO)
-    G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle>]
+    G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle> + #<workspace_r>]
     o<Probe_top_right_edge_angle> return
   o<150> endif
 


### PR DESCRIPTION
The probing math is relative to workspace coordinates. The `g10 l2` correctly adds the former work offsets to the calculated new origin, but it forgets the former rotation offset. This PR fixes that for all 8 corner edge probing commands.

After this PR, the measured angle should converge towards zero  when repeatedly probing and setting the wco angle.