### PR TITLE
Revert slider rename `max_velocity_status` > `max_vel_slider`

### DIFF
--- a/src/probe_basic/probe_basic.ui
+++ b/src/probe_basic/probe_basic.ui
@@ -33006,7 +33006,7 @@ LOAD</string>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="StatusLabel" name="max_velocity_status">
+          <widget class="StatusLabel" name="max_vel_slider">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
              <horstretch>0</horstretch>


### PR DESCRIPTION
missed that this one is used by the probe routines
