### PR TITLE
Sub tweaks

### DIFF
--- a/configs/atc_sim/macros_sim_inch/clamptool.ngc
+++ b/configs/atc_sim/macros_sim_inch/clamptool.ngc
@@ -4,7 +4,7 @@ M65 P2 ; clamp the tool
 
 M66 P5 L3 Q2 ; check the clamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<clamptool> endsub [1]

--- a/configs/atc_sim/macros_sim_inch/extendatc.ngc
+++ b/configs/atc_sim/macros_sim_inch/extendatc.ngc
@@ -1,10 +1,16 @@
 o<extendatc> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/atc_sim/macros_sim_inch/extendatc.ngc
+++ b/configs/atc_sim/macros_sim_inch/extendatc.ngc
@@ -20,7 +20,7 @@ M64 P0 ; Move Carousel OUT
 M66 P1 L3 Q5 ; check for carousel out position sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 o<extendatc> endsub [1]

--- a/configs/atc_sim/macros_sim_inch/extendatc.ngc
+++ b/configs/atc_sim/macros_sim_inch/extendatc.ngc
@@ -1,6 +1,12 @@
 o<extendatc> sub
 
-G0 G53 Z0
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+
+#<atc_z_tool_change_height> = -3.9000
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 M65 P1 ; Turn off carousel home solenoid
 M64 P0 ; Move Carousel OUT

--- a/configs/atc_sim/macros_sim_inch/go_to_g30.ngc
+++ b/configs/atc_sim/macros_sim_inch/go_to_g30.ngc
@@ -1,5 +1,6 @@
 o<go_to_g30> sub
 
+M73
 G90
 G53 G0 Z0
 G30

--- a/configs/atc_sim/macros_sim_inch/go_to_home.ngc
+++ b/configs/atc_sim/macros_sim_inch/go_to_home.ngc
@@ -1,5 +1,6 @@
 o<go_to_home> sub
 
+M73
 G90
 G53 G0 Z0
 G53 G0 X0 Y0

--- a/configs/atc_sim/macros_sim_inch/go_to_zero.ngc
+++ b/configs/atc_sim/macros_sim_inch/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+M73
 G90
 o100 if [#5422 LT 0]
     G0 Z0

--- a/configs/atc_sim/macros_sim_inch/go_to_zero.ngc
+++ b/configs/atc_sim/macros_sim_inch/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+G90
 o100 if [#5422 LT 0]
     G0 Z0
     G0 X0 Y0

--- a/configs/atc_sim/macros_sim_inch/load_spindle_safety.ngc
+++ b/configs/atc_sim/macros_sim_inch/load_spindle_safety.ngc
@@ -12,7 +12,7 @@
 o<load_spindle_safety> sub
 (PRINT, o<load_spindle_safety>)
 
-#<load_spindle_tool_number> = #1
+#<load_spindle_tool_number> = #1 ; this is the value form the ATC tab
 #<activate_programmable_coolant> = #2
 #<horizontal_spindle_nozzle_dist> = #3
 #<vertical_spindle_nozzle_dist> = #4

--- a/configs/atc_sim/macros_sim_inch/load_spindle_safety_2.ngc
+++ b/configs/atc_sim/macros_sim_inch/load_spindle_safety_2.ngc
@@ -12,7 +12,7 @@
 o<load_spindle_safety_2> sub
 (PRINT, o<load_spindle_safety_2>)
 
-#<load_spindle_tool_number_2> = #1
+#<load_spindle_tool_number_2> = #1 ; this is the value form the TOOL tab
 #<activate_programmable_coolant> = #2
 #<horizontal_spindle_nozzle_dist> = #3
 #<vertical_spindle_nozzle_dist> = #4

--- a/configs/atc_sim/macros_sim_inch/m10.ngc
+++ b/configs/atc_sim/macros_sim_inch/m10.ngc
@@ -4,7 +4,7 @@ o<m10> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M10> P#<p>)
+(PRINT, o<m10> P#<p>)
 
 o100 if [#3989 NE 1]
     M13
@@ -17,7 +17,7 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
 o101 endif
 
 #<steps> = [#3990 - #<p>]
-(PRINT, o<M10> P#<p>, steps=#<steps>)
+(PRINT, o<m10> P#<p>, steps=#<steps>)
 o110 if [#<steps> GT [#<number_of_pockets> / 2]]
     #<steps>=[#<steps> - #<number_of_pockets>]
 o110 endif
@@ -31,6 +31,7 @@ o130 elseif [#<steps> LT 0]
     M11 P[#<steps>]
 o130 endif
 
+(PRINT, o<m10> endsub)
 o<m10> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m11.ngc
+++ b/configs/atc_sim/macros_sim_inch/m11.ngc
@@ -5,7 +5,7 @@ o<m11> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M11> P#<p>)
+(PRINT, o<m11> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P4 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990+2] MOD #<number_of_pockets>]-1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P4 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m11> endsub)
 o<m11> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m12.ngc
+++ b/configs/atc_sim/macros_sim_inch/m12.ngc
@@ -5,7 +5,7 @@ o<m12> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M12> P#<p>)
+(PRINT, o<m12> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P3 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990-2] MOD #<number_of_pockets>]+1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P3 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m12> endsub)
 o<m12> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m13.ngc
+++ b/configs/atc_sim/macros_sim_inch/m13.ngc
@@ -4,7 +4,7 @@ o<m13> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M13>)
+(PRINT, o<m13>)
 
 (DEBUG, EVAL[vcp.getWidget{"dynatc"}.atc_message{"REFERENCING"}])
 
@@ -12,7 +12,7 @@ M64 P3 ; Move Motor FWD
 M66 P3 L1 Q20 ; wait for rising edge on home index
 o100 if [#5399 LT 0]
     M65 P3 ; stop motor
-    (abort, failed to home carousel)
+    (abort, Failed to home carousel)
 o100 endif
 
 #3990 = 1
@@ -36,6 +36,7 @@ o120 endwhile
 
 M61 Q#3991 G43 H#3991 #5210 = 0
 
+(PRINT, o<m13> endsub)
 o<m13> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m21.ngc
+++ b/configs/atc_sim/macros_sim_inch/m21.ngc
@@ -8,7 +8,7 @@ o<m21> sub
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.9000
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/atc_sim/macros_sim_inch/m21.ngc
+++ b/configs/atc_sim/macros_sim_inch/m21.ngc
@@ -3,12 +3,18 @@ o<m21> sub
 ; Move Carousel to the tool change position - OUT
 ; then unload any tool in the spindle into the current pocket
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/atc_sim/macros_sim_inch/m21.ngc
+++ b/configs/atc_sim/macros_sim_inch/m21.ngc
@@ -5,7 +5,7 @@ o<m21> sub
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M21>)
+(PRINT, o<m21>)
 
 #<atc_z_tool_change_height> = -3.9000
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -29,7 +29,7 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 M24 ; activate drawbar, release the tool
@@ -39,6 +39,7 @@ G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 #3991 = 0; save fact there is now no tool in the spindle
 
+(PRINT, o<m21> endsub)
 o<m21> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m22.ngc
+++ b/configs/atc_sim/macros_sim_inch/m22.ngc
@@ -7,7 +7,7 @@ o<m22> sub
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.9000
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 ;M19 R0 Q2
 M24

--- a/configs/atc_sim/macros_sim_inch/m22.ngc
+++ b/configs/atc_sim/macros_sim_inch/m22.ngc
@@ -2,12 +2,18 @@ o<m22> sub
 
 ; Move Carousel to the home position - IN
 ; after loading any tool in the current pocket to the spindle
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 ;M19 R0 Q2
 M24

--- a/configs/atc_sim/macros_sim_inch/m22.ngc
+++ b/configs/atc_sim/macros_sim_inch/m22.ngc
@@ -4,7 +4,7 @@ o<m22> sub
 ; after loading any tool in the current pocket to the spindle
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M22>)
+(PRINT, o<m22>)
 
 #<atc_z_tool_change_height> = -3.9000
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -24,18 +24,19 @@ M65 P2 ; release the drawbar to clamp the tool
 M5
 M66 P5 L3 Q1 ; check the tool clamped sensor
 o100 if [#5399 LT 0]
-    (abort, failed to reclamp tool)
+    (abort, Failed to reclamp tool)
 o100 endif
 
 M65 P0 ; Move Carousel home
 M66 P0 L3 Q4 ; check carousel in position sensor
 o110 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o110 endif
 
 ;M65 P1
 
+(PRINT, o<m22> endsub)
 o<m22> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m24.ngc
+++ b/configs/atc_sim/macros_sim_inch/m24.ngc
@@ -8,6 +8,7 @@ o100 if [#5399 LT 0]
     (abort, failed to release tool) ; abort if the sensor does not activate in 3 seconds
 o100 endif
 
+(PRINT, o<m24> endsub)
 o<m24> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m25.ngc
+++ b/configs/atc_sim/macros_sim_inch/m25.ngc
@@ -6,9 +6,10 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
+(PRINT, o<m25> endsub)
 o<m25> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/m25.ngc
+++ b/configs/atc_sim/macros_sim_inch/m25.ngc
@@ -2,6 +2,7 @@ o<m25> sub
 (PRINT, o<m25>)
 
 M64 P0 ; Move Carousel out
+
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid

--- a/configs/atc_sim/macros_sim_inch/move_head_above_carousel.ngc
+++ b/configs/atc_sim/macros_sim_inch/move_head_above_carousel.ngc
@@ -1,10 +1,16 @@
 o<move_head_above_carousel> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-#<atc_z_tool_change_height> = -3.1900
+#<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/atc_sim/macros_sim_inch/move_head_above_carousel.ngc
+++ b/configs/atc_sim/macros_sim_inch/move_head_above_carousel.ngc
@@ -4,7 +4,7 @@ o<move_head_above_carousel> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/atc_sim/macros_sim_inch/move_tool_to_carousel_height.ngc
+++ b/configs/atc_sim/macros_sim_inch/move_tool_to_carousel_height.ngc
@@ -1,9 +1,15 @@
 o<move_tool_to_carousel_height> sub
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-#<atc_z_tool_change_height> = -3.1900
+#<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/atc_sim/macros_sim_inch/move_tool_to_carousel_height.ngc
+++ b/configs/atc_sim/macros_sim_inch/move_tool_to_carousel_height.ngc
@@ -3,7 +3,7 @@ o<move_tool_to_carousel_height> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/atc_sim/macros_sim_inch/probe_top_right_edge_angle.ngc
+++ b/configs/atc_sim/macros_sim_inch/probe_top_right_edge_angle.ngc
@@ -7,7 +7,7 @@
 (step off width distance and within max z distance)
 (ensure all settings have been set properly according to help diagrams)
 
-o<Probe_top_right_edge_angle> sub
+o<probe_top_right_edge_angle> sub
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)
@@ -37,7 +37,7 @@ o<Probe_top_right_edge_angle> sub
   (Probe Tool Safety Check)
   o100 if [#5400 NE #<probe_tool_number>]
      (MSG, Specified probe tool #<probe_tool_number> not in spindle, aborting)
-     o<Probe_top_right_edge_angle> return
+     o<probe_top_right_edge_angle> return
   o100 endif
 
   (Probe Diameter)
@@ -68,7 +68,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o110 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o110 endif
 
   (edge width move to edge second probing point)
@@ -84,7 +84,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o120 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o120 endif
 
   #<edge_delta> = [#<x_minus_zero_edge_start> - #<x_minus_zero_edge_end>]
@@ -109,16 +109,16 @@ o<Probe_top_right_edge_angle> sub
   o130 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 0]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o130 endif
 
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o140 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o140 endif
 
-o<Probe_top_right_edge_angle> endsub
+o<probe_top_right_edge_angle> endsub
 
 M2 (end program)

--- a/configs/atc_sim/macros_sim_inch/retractatc.ngc
+++ b/configs/atc_sim/macros_sim_inch/retractatc.ngc
@@ -6,7 +6,7 @@ M64 P1 ; Move Carousel IN
 M66 P0 L3 Q5 ; check carousel in position sensor
 o100 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o100 endif
 M65 P1
 

--- a/configs/atc_sim/macros_sim_inch/tool_touch_off.ngc
+++ b/configs/atc_sim/macros_sim_inch/tool_touch_off.ngc
@@ -1,5 +1,7 @@
 o<tool_touch_off> sub
 
+; NOTE this routine used G59.3, and this needs to be set to 0,0,0 for everything to work correctly
+
 #<fast_probe_fr> = #1    (set from probe screen fast probe feed rate)
 #<slow_probe_fr> = #2    (set from probe screen slow probe feedrate)
 #<z_max_travel> = #3    (max z distance the tool travels before erroring out if not contact is made)

--- a/configs/atc_sim/macros_sim_inch/toolchange.ngc
+++ b/configs/atc_sim/macros_sim_inch/toolchange.ngc
@@ -6,8 +6,10 @@ o<toolchange> sub
 ; Parameters #4001 to #4024 are used to track which tool is in which pocket (persistently)
 ; Parameter #4000 is not populated just used in the maths to calculate the above numbers
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-(PRINT, o<toolchange>)
+(PRINT, o<toolchange> selected_tool: #<selected_tool>, tool_in_spindle: #<tool_in_spindle>, selected_pocket: #<selected_pocket>, current_pocket: #<current_pocket>, task: #<_task>)
 
 o100 if [#<_task> EQ 0]
     (DEBUG, Task is null)
@@ -20,28 +22,46 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
     #<number_of_pockets> = #<_ini[atc]pockets>
 o101 endif
 
+#<atc_z_tool_change_height> = -3.9000
+o102 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o102 endif
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o103 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o103 endif
+
 ; assign the programmable coolant parameters
 #<activate_programmable_coolant> = #1 (=0)
 #<horizontal_spindle_nozzle_dist> = #2 (=0)
 #<vertical_spindle_nozzle_dist> = #3 (=0)
 #<pc_angle_offset> = #4 (=0)
 
-; assign the variables passed by M6 to some parameters
+; assign the variables passed by M6 change_prolog to some parameters
 #100 = #<selected_tool>
 #110 = #<tool_in_spindle>
 #120 = #<selected_pocket>
+#121 = #<current_pocket>
+; NOTE:
+;      The legacy names *selected_pocket* and *current_pocket* actually reference
+;      a sequential tooldata index for tool items loaded from a tool
+;      table ([EMCIO]TOOL_TABLE) or via a tooldata database ([EMCIO]DB_PROGRAM)
 
-o110 if [#100 EQ #110] ; checks if tool in the spindle is same as requested
+o110 if [#<selected_tool> EQ #<tool_in_spindle>] ; checks if tool in the spindle is same as requested
     o<toolchange> endsub [1]
     M2
 o110 endif
+
+o111 if [#3991 NE #<tool_in_spindle>]
+    (PRINT, o<toolchange> tool_in_spindle does not match 3991)
+o111 endif
 
 #<next_pocket> = 0 ; assigns 0 to the next pocket for a later check if the tool is found in the carousel
 #<open_pocket> = 0
 #130 = #<number_of_pockets> ; assign test parameter the number of pockets in the carousel
 
 o120 do
-    o121 if [#[4000 + #130] EQ #100] ; checks all pockets to see if it contains tool number requested as the new tool
+    o121 if [#[4000 + #130] EQ #<selected_tool>] ; checks all pockets to see if it contains tool number requested as the new tool
         #<next_pocket> = #130 ; if tool is found in pocket, assigns the next pocket
     o121 endif
     o122 if [#[4000 + #130] EQ 0] ; checks if the pocket is empty, last pocket checked will be the lowest empty pocket number, for putting tool in spindle away.
@@ -50,7 +70,7 @@ o120 do
     #130 = [#130 - 1]
 o120 while [#130 GT 0]
 o130 if [#<next_pocket> EQ 0] ; if tool is not found, aborts and sends a message
-    (abort, tool not in carousel)
+    (abort, Tool T%d#<selected_tool> not found in carousel)
 o130 endif
 
 ; now we know which pocket the next tool is sitting in
@@ -59,7 +79,7 @@ o130 endif
 
 o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spindle
     o141 if [#<open_pocket> EQ 0] ; If there is a tool in the spindle, checks if there is an open pocket
-        (abort, carousel is full, cant put away tool in into carousel)
+        (abort, Carousel is full, cant put away tool T#<tool_in_spindle> in into carousel)
     o141 endif
     M10 P[#<open_pocket>] ; move carousel to an open pocket
     M21 ; puts the tool in spindle away into the open pocket
@@ -67,10 +87,12 @@ o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spind
     #140 = #<open_pocket>
     #[4000 + #140] = #<tool_in_spindle> ; save tool number in pocket
     #3991 = 0 ; empty tool in the spindle
+    M61 Q0
+    G49
 o140 endif
 
 G90
-G0 G53 Z0
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M10 P#<next_pocket> ; set the carousel to move to the right pocket for the selected tool
@@ -79,7 +101,7 @@ o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M66 P1 L3 Q5 ; check carousel out position sensor
     o151 if [#5399 LT 0]
         M65 P0 ; turn off the solenoid to send atc to tool change
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o151 endif
     M65 P0
 
@@ -95,7 +117,7 @@ o150 else
     M66 P0 L3 Q4 ; check carousel in position sensor
     o152 if [#5399 LT 0]
         M65 P1 ; turn off the solenoid to send atc home
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o152 endif
     M65 P1
 o150 endif
@@ -112,6 +134,7 @@ o170 if [#<activate_programmable_coolant> EQ 1]
     o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
 o170 endif
 
+(PRINT, o<toolchange> endsub)
 o<toolchange> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_inch/unclamptool.ngc
+++ b/configs/atc_sim/macros_sim_inch/unclamptool.ngc
@@ -4,7 +4,7 @@ M64 P2 ; unclamp the tool
 
 M66 P2 L3 Q2 ; check the unclamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<unclamptool> endsub [1]

--- a/configs/atc_sim/macros_sim_metric/clamptool.ngc
+++ b/configs/atc_sim/macros_sim_metric/clamptool.ngc
@@ -4,7 +4,7 @@ M65 P2 ; clamp the tool
 
 M66 P5 L3 Q2 ; check the clamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<clamptool> endsub [1]

--- a/configs/atc_sim/macros_sim_metric/extendatc.ngc
+++ b/configs/atc_sim/macros_sim_metric/extendatc.ngc
@@ -1,10 +1,16 @@
 o<extendatc> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/atc_sim/macros_sim_metric/extendatc.ngc
+++ b/configs/atc_sim/macros_sim_metric/extendatc.ngc
@@ -20,7 +20,7 @@ M64 P0 ; Move Carousel OUT
 M66 P1 L3 Q5 ; check for carousel out position sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 o<extendatc> endsub [1]

--- a/configs/atc_sim/macros_sim_metric/extendatc.ngc
+++ b/configs/atc_sim/macros_sim_metric/extendatc.ngc
@@ -1,6 +1,12 @@
 o<extendatc> sub
 
-G0 G53 Z0
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+
+#<atc_z_tool_change_height> = -3.9000
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 M65 P1 ; Turn off carousel home solenoid
 M64 P0 ; Move Carousel OUT

--- a/configs/atc_sim/macros_sim_metric/go_to_g30.ngc
+++ b/configs/atc_sim/macros_sim_metric/go_to_g30.ngc
@@ -1,5 +1,6 @@
 o<go_to_g30> sub
 
+M73
 G90
 G53 G0 Z0
 G30

--- a/configs/atc_sim/macros_sim_metric/go_to_home.ngc
+++ b/configs/atc_sim/macros_sim_metric/go_to_home.ngc
@@ -1,5 +1,6 @@
 o<go_to_home> sub
 
+M73
 G90
 G53 G0 Z0
 G53 G0 X0 Y0

--- a/configs/atc_sim/macros_sim_metric/go_to_zero.ngc
+++ b/configs/atc_sim/macros_sim_metric/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+M73
 G90
 o100 if [#5422 LT 0]
     G0 Z0

--- a/configs/atc_sim/macros_sim_metric/go_to_zero.ngc
+++ b/configs/atc_sim/macros_sim_metric/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+G90
 o100 if [#5422 LT 0]
     G0 Z0
     G0 X0 Y0

--- a/configs/atc_sim/macros_sim_metric/load_spindle_safety.ngc
+++ b/configs/atc_sim/macros_sim_metric/load_spindle_safety.ngc
@@ -12,7 +12,7 @@
 o<load_spindle_safety> sub
 (PRINT, o<load_spindle_safety>)
 
-#<load_spindle_tool_number> = #1
+#<load_spindle_tool_number> = #1 ; this is the value form the ATC tab
 #<activate_programmable_coolant> = #2
 #<horizontal_spindle_nozzle_dist> = #3
 #<vertical_spindle_nozzle_dist> = #4

--- a/configs/atc_sim/macros_sim_metric/load_spindle_safety_2.ngc
+++ b/configs/atc_sim/macros_sim_metric/load_spindle_safety_2.ngc
@@ -12,7 +12,7 @@
 o<load_spindle_safety_2> sub
 (PRINT, o<load_spindle_safety_2>)
 
-#<load_spindle_tool_number_2> = #1
+#<load_spindle_tool_number_2> = #1 ; this is the value form the TOOL tab
 #<activate_programmable_coolant> = #2
 #<horizontal_spindle_nozzle_dist> = #3
 #<vertical_spindle_nozzle_dist> = #4

--- a/configs/atc_sim/macros_sim_metric/m10.ngc
+++ b/configs/atc_sim/macros_sim_metric/m10.ngc
@@ -4,7 +4,7 @@ o<m10> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M10> P#<p>)
+(PRINT, o<m10> P#<p>)
 
 o100 if [#3989 NE 1]
     M13
@@ -17,7 +17,7 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
 o101 endif
 
 #<steps> = [#3990 - #<p>]
-(PRINT, o<M10> P#<p>, steps=#<steps>)
+(PRINT, o<m10> P#<p>, steps=#<steps>)
 o110 if [#<steps> GT [#<number_of_pockets> / 2]]
     #<steps>=[#<steps> - #<number_of_pockets>]
 o110 endif
@@ -31,6 +31,7 @@ o130 elseif [#<steps> LT 0]
     M11 P[#<steps>]
 o130 endif
 
+(PRINT, o<m10> endsub)
 o<m10> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m11.ngc
+++ b/configs/atc_sim/macros_sim_metric/m11.ngc
@@ -5,7 +5,7 @@ o<m11> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M11> P#<p>)
+(PRINT, o<m11> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P4 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990+2] MOD #<number_of_pockets>]-1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P4 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m11> endsub)
 o<m11> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m12.ngc
+++ b/configs/atc_sim/macros_sim_metric/m12.ngc
@@ -5,7 +5,7 @@ o<m12> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M12> P#<p>)
+(PRINT, o<m12> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P3 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990-2] MOD #<number_of_pockets>]+1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P3 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m12> endsub)
 o<m12> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m13.ngc
+++ b/configs/atc_sim/macros_sim_metric/m13.ngc
@@ -4,7 +4,7 @@ o<m13> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M13>)
+(PRINT, o<m13>)
 
 (DEBUG, EVAL[vcp.getWidget{"dynatc"}.atc_message{"REFERENCING"}])
 
@@ -12,7 +12,7 @@ M64 P3 ; Move Motor FWD
 M66 P3 L1 Q20 ; wait for rising edge on home index
 o100 if [#5399 LT 0]
     M65 P3 ; stop motor
-    (abort, failed to home carousel)
+    (abort, Failed to home carousel)
 o100 endif
 
 #3990 = 1
@@ -36,6 +36,7 @@ o120 endwhile
 
 M61 Q#3991 G43 H#3991 #5210 = 0
 
+(PRINT, o<m13> endsub)
 o<m13> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m13.ngc
+++ b/configs/atc_sim/macros_sim_metric/m13.ngc
@@ -9,7 +9,7 @@ o<m13> sub
 (DEBUG, EVAL[vcp.getWidget{"dynatc"}.atc_message{"REFERENCING"}])
 
 M64 P3 ; Move Motor FWD
-M66 P3 L1 Q20 ; wait for rising edge on rotation index
+M66 P3 L1 Q20 ; wait for rising edge on home index
 o100 if [#5399 LT 0]
     M65 P3 ; stop motor
     (abort, failed to home carousel)

--- a/configs/atc_sim/macros_sim_metric/m21.ngc
+++ b/configs/atc_sim/macros_sim_metric/m21.ngc
@@ -8,7 +8,7 @@ o<m21> sub
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.9000
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/atc_sim/macros_sim_metric/m21.ngc
+++ b/configs/atc_sim/macros_sim_metric/m21.ngc
@@ -3,12 +3,18 @@ o<m21> sub
 ; Move Carousel to the tool change position - OUT
 ; then unload any tool in the spindle into the current pocket
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/atc_sim/macros_sim_metric/m21.ngc
+++ b/configs/atc_sim/macros_sim_metric/m21.ngc
@@ -5,7 +5,7 @@ o<m21> sub
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M21>)
+(PRINT, o<m21>)
 
 #<atc_z_tool_change_height> = -3.9000
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -29,7 +29,7 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 M24 ; activate drawbar, release the tool
@@ -39,6 +39,7 @@ G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 #3991 = 0; save fact there is now no tool in the spindle
 
+(PRINT, o<m21> endsub)
 o<m21> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m22.ngc
+++ b/configs/atc_sim/macros_sim_metric/m22.ngc
@@ -7,7 +7,7 @@ o<m22> sub
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.9000
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 ;M19 R0 Q2
 M24

--- a/configs/atc_sim/macros_sim_metric/m22.ngc
+++ b/configs/atc_sim/macros_sim_metric/m22.ngc
@@ -2,12 +2,18 @@ o<m22> sub
 
 ; Move Carousel to the home position - IN
 ; after loading any tool in the current pocket to the spindle
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 ;M19 R0 Q2
 M24

--- a/configs/atc_sim/macros_sim_metric/m22.ngc
+++ b/configs/atc_sim/macros_sim_metric/m22.ngc
@@ -4,7 +4,7 @@ o<m22> sub
 ; after loading any tool in the current pocket to the spindle
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M22>)
+(PRINT, o<m22>)
 
 #<atc_z_tool_change_height> = -3.9000
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -24,18 +24,19 @@ M65 P2 ; release the drawbar to clamp the tool
 M5
 M66 P5 L3 Q1 ; check the tool clamped sensor
 o100 if [#5399 LT 0]
-    (abort, failed to reclamp tool)
+    (abort, Failed to reclamp tool)
 o100 endif
 
 M65 P0 ; Move Carousel home
 M66 P0 L3 Q4 ; check carousel in position sensor
 o110 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o110 endif
 
 ;M65 P1
 
+(PRINT, o<m22> endsub)
 o<m22> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m24.ngc
+++ b/configs/atc_sim/macros_sim_metric/m24.ngc
@@ -8,6 +8,7 @@ o100 if [#5399 LT 0]
     (abort, failed to release tool) ; abort if the sensor does not activate in 3 seconds
 o100 endif
 
+(PRINT, o<m24> endsub)
 o<m24> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m25.ngc
+++ b/configs/atc_sim/macros_sim_metric/m25.ngc
@@ -6,9 +6,10 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
+(PRINT, o<m25> endsub)
 o<m25> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/m25.ngc
+++ b/configs/atc_sim/macros_sim_metric/m25.ngc
@@ -2,6 +2,7 @@ o<m25> sub
 (PRINT, o<m25>)
 
 M64 P0 ; Move Carousel out
+
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid

--- a/configs/atc_sim/macros_sim_metric/move_head_above_carousel.ngc
+++ b/configs/atc_sim/macros_sim_metric/move_head_above_carousel.ngc
@@ -1,10 +1,16 @@
 o<move_head_above_carousel> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-#<atc_z_tool_change_height> = -3.1900
+#<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/atc_sim/macros_sim_metric/move_head_above_carousel.ngc
+++ b/configs/atc_sim/macros_sim_metric/move_head_above_carousel.ngc
@@ -4,7 +4,7 @@ o<move_head_above_carousel> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/atc_sim/macros_sim_metric/move_tool_to_carousel_height.ngc
+++ b/configs/atc_sim/macros_sim_metric/move_tool_to_carousel_height.ngc
@@ -1,9 +1,15 @@
 o<move_tool_to_carousel_height> sub
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-#<atc_z_tool_change_height> = -3.1900
+#<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/atc_sim/macros_sim_metric/move_tool_to_carousel_height.ngc
+++ b/configs/atc_sim/macros_sim_metric/move_tool_to_carousel_height.ngc
@@ -3,7 +3,7 @@ o<move_tool_to_carousel_height> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/atc_sim/macros_sim_metric/probe_top_right_edge_angle.ngc
+++ b/configs/atc_sim/macros_sim_metric/probe_top_right_edge_angle.ngc
@@ -7,7 +7,7 @@
 (step off width distance and within max z distance)
 (ensure all settings have been set properly according to help diagrams)
 
-o<Probe_top_right_edge_angle> sub
+o<probe_top_right_edge_angle> sub
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)
@@ -37,7 +37,7 @@ o<Probe_top_right_edge_angle> sub
   (Probe Tool Safety Check)
   o100 if [#5400 NE #<probe_tool_number>]
      (MSG, Specified probe tool #<probe_tool_number> not in spindle, aborting)
-     o<Probe_top_right_edge_angle> return
+     o<probe_top_right_edge_angle> return
   o100 endif
 
   (Probe Diameter)
@@ -68,7 +68,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o110 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o110 endif
 
   (edge width move to edge second probing point)
@@ -84,7 +84,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o120 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o120 endif
 
   #<edge_delta> = [#<x_minus_zero_edge_start> - #<x_minus_zero_edge_end>]
@@ -109,16 +109,16 @@ o<Probe_top_right_edge_angle> sub
   o130 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 0]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o130 endif
 
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o140 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o140 endif
 
-o<Probe_top_right_edge_angle> endsub
+o<probe_top_right_edge_angle> endsub
 
 M2 (end program)

--- a/configs/atc_sim/macros_sim_metric/retractatc.ngc
+++ b/configs/atc_sim/macros_sim_metric/retractatc.ngc
@@ -6,7 +6,7 @@ M64 P1 ; Move Carousel IN
 M66 P0 L3 Q5 ; check carousel in position sensor
 o100 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o100 endif
 M65 P1
 

--- a/configs/atc_sim/macros_sim_metric/tool_touch_off.ngc
+++ b/configs/atc_sim/macros_sim_metric/tool_touch_off.ngc
@@ -1,5 +1,7 @@
 o<tool_touch_off> sub
 
+; NOTE this routine used G59.3, and this needs to be set to 0,0,0 for everything to work correctly
+
 #<fast_probe_fr> = #1    (set from probe screen fast probe feed rate)
 #<slow_probe_fr> = #2    (set from probe screen slow probe feedrate)
 #<z_max_travel> = #3    (max z distance the tool travels before erroring out if not contact is made)

--- a/configs/atc_sim/macros_sim_metric/toolchange.ngc
+++ b/configs/atc_sim/macros_sim_metric/toolchange.ngc
@@ -6,8 +6,10 @@ o<toolchange> sub
 ; Parameters #4001 to #4024 are used to track which tool is in which pocket (persistently)
 ; Parameter #4000 is not populated just used in the maths to calculate the above numbers
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-(PRINT, o<toolchange>)
+(PRINT, o<toolchange> selected_tool: #<selected_tool>, tool_in_spindle: #<tool_in_spindle>, selected_pocket: #<selected_pocket>, current_pocket: #<current_pocket>, task: #<_task>)
 
 o100 if [#<_task> EQ 0]
     (DEBUG, Task is null)
@@ -20,28 +22,46 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
     #<number_of_pockets> = #<_ini[atc]pockets>
 o101 endif
 
+#<atc_z_tool_change_height> = -3.9000
+o102 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o102 endif
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o103 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o103 endif
+
 ; assign the programmable coolant parameters
 #<activate_programmable_coolant> = #1 (=0)
 #<horizontal_spindle_nozzle_dist> = #2 (=0)
 #<vertical_spindle_nozzle_dist> = #3 (=0)
 #<pc_angle_offset> = #4 (=0)
 
-; assign the variables passed by M6 to some parameters
+; assign the variables passed by M6 change_prolog to some parameters
 #100 = #<selected_tool>
 #110 = #<tool_in_spindle>
 #120 = #<selected_pocket>
+#121 = #<current_pocket>
+; NOTE:
+;      The legacy names *selected_pocket* and *current_pocket* actually reference
+;      a sequential tooldata index for tool items loaded from a tool
+;      table ([EMCIO]TOOL_TABLE) or via a tooldata database ([EMCIO]DB_PROGRAM)
 
-o110 if [#100 EQ #110] ; checks if tool in the spindle is same as requested
+o110 if [#<selected_tool> EQ #<tool_in_spindle>] ; checks if tool in the spindle is same as requested
     o<toolchange> endsub [1]
     M2
 o110 endif
+
+o111 if [#3991 NE #<tool_in_spindle>]
+    (PRINT, o<toolchange> tool_in_spindle does not match 3991)
+o111 endif
 
 #<next_pocket> = 0 ; assigns 0 to the next pocket for a later check if the tool is found in the carousel
 #<open_pocket> = 0
 #130 = #<number_of_pockets> ; assign test parameter the number of pockets in the carousel
 
 o120 do
-    o121 if [#[4000 + #130] EQ #100] ; checks all pockets to see if it contains tool number requested as the new tool
+    o121 if [#[4000 + #130] EQ #<selected_tool>] ; checks all pockets to see if it contains tool number requested as the new tool
         #<next_pocket> = #130 ; if tool is found in pocket, assigns the next pocket
     o121 endif
     o122 if [#[4000 + #130] EQ 0] ; checks if the pocket is empty, last pocket checked will be the lowest empty pocket number, for putting tool in spindle away.
@@ -50,7 +70,7 @@ o120 do
     #130 = [#130 - 1]
 o120 while [#130 GT 0]
 o130 if [#<next_pocket> EQ 0] ; if tool is not found, aborts and sends a message
-    (abort, tool not in carousel)
+    (abort, Tool T%d#<selected_tool> not found in carousel)
 o130 endif
 
 ; now we know which pocket the next tool is sitting in
@@ -59,7 +79,7 @@ o130 endif
 
 o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spindle
     o141 if [#<open_pocket> EQ 0] ; If there is a tool in the spindle, checks if there is an open pocket
-        (abort, carousel is full, cant put away tool in into carousel)
+        (abort, Carousel is full, cant put away tool T#<tool_in_spindle> in into carousel)
     o141 endif
     M10 P[#<open_pocket>] ; move carousel to an open pocket
     M21 ; puts the tool in spindle away into the open pocket
@@ -67,10 +87,12 @@ o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spind
     #140 = #<open_pocket>
     #[4000 + #140] = #<tool_in_spindle> ; save tool number in pocket
     #3991 = 0 ; empty tool in the spindle
+    M61 Q0
+    G49
 o140 endif
 
 G90
-G0 G53 Z0
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M10 P#<next_pocket> ; set the carousel to move to the right pocket for the selected tool
@@ -79,7 +101,7 @@ o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M66 P1 L3 Q5 ; check carousel out position sensor
     o151 if [#5399 LT 0]
         M65 P0 ; turn off the solenoid to send atc to tool change
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o151 endif
     M65 P0
 
@@ -95,7 +117,7 @@ o150 else
     M66 P0 L3 Q4 ; check carousel in position sensor
     o152 if [#5399 LT 0]
         M65 P1 ; turn off the solenoid to send atc home
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o152 endif
     M65 P1
 o150 endif
@@ -112,6 +134,7 @@ o170 if [#<activate_programmable_coolant> EQ 1]
     o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
 o170 endif
 
+(PRINT, o<toolchange> endsub)
 o<toolchange> endsub [1]
 
 M2

--- a/configs/atc_sim/macros_sim_metric/unclamptool.ngc
+++ b/configs/atc_sim/macros_sim_metric/unclamptool.ngc
@@ -4,7 +4,7 @@ M64 P2 ; unclamp the tool
 
 M66 P2 L3 Q2 ; check the unclamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<unclamptool> endsub [1]

--- a/configs/atc_sim/vmc_index.ini
+++ b/configs/atc_sim/vmc_index.ini
@@ -41,6 +41,10 @@ PATH_APPEND = ./python/python-stdglue/
 [ATC]
 # Carousel image available for 8, 10, 12, 14, 16, 18, 20, 21, 24
 POCKETS = 12
+# The Z height you spindle needs to be at to clamp/unclamp a tool form the ATC
+Z_TOOL_CHANGE_HEIGHT = -3.9000
+# The Z clearance height you spindle needs to be at to safely clear the ATC
+Z_TOOL_CLEARANCE_HEIGHT = -0.1
 
 [RS274NGC]
 PROGRAM_PREFIX = ~/linuxcnc/nc_files

--- a/configs/atc_sim/vmc_index_inch.ini
+++ b/configs/atc_sim/vmc_index_inch.ini
@@ -43,6 +43,10 @@ PATH_APPEND = ./python/python-stdglue/
 [ATC]
 # Carousel image available for 8, 10, 12, 14, 16, 18, 20, 21, 24
 POCKETS = 12
+# The Z height you spindle needs to be at to clamp/unclamp a tool form the ATC
+Z_TOOL_CHANGE_HEIGHT = -3.9000
+# The Z clearance height you spindle needs to be at to safely clear the ATC
+Z_TOOL_CLEARANCE_HEIGHT = -0.1
 STEP_TIME = 500
 
 [RS274NGC]

--- a/configs/atc_sim/vmc_index_metric.ini
+++ b/configs/atc_sim/vmc_index_metric.ini
@@ -43,6 +43,10 @@ PATH_APPEND = ./python/python-stdglue/
 [ATC]
 # Carousel image available for 8, 10, 12, 14, 16, 18, 20, 21, 24
 POCKETS = 12
+# The Z height you spindle needs to be at to clamp/unclamp a tool form the ATC
+Z_TOOL_CHANGE_HEIGHT = -3.9000
+# The Z clearance height you spindle needs to be at to safely clear the ATC
+Z_TOOL_CLEARANCE_HEIGHT = -0.1
 
 [RS274NGC]
 RS274NGC_STARTUP_CODE = F10 S300 G21 G17 G40 G49 G54 G64 P0.001 G80 G90 G91.1 G92.1 G94 G97 G98

--- a/configs/probe_basic/probe_basic.ini
+++ b/configs/probe_basic/probe_basic.ini
@@ -51,6 +51,10 @@ PROGRAM_EXTENSION = .png,.gif,.jpg Greyscale Depth Image
 [ATC]
 # Carousel image available for 8, 10, 12, 14, 16, 18, 20, 21, 24
 POCKETS = 12
+# The Z height you spindle needs to be at to clamp/unclamp a tool form the ATC
+Z_TOOL_CHANGE_HEIGHT = -3.1900
+# The Z clearance height you spindle needs to be at to safely clear the ATC
+Z_TOOL_CLEARANCE_HEIGHT = -0.1
 STEP_TIME = 500
 
 [RS274NGC]

--- a/configs/probe_basic/subroutines/clamptool.ngc
+++ b/configs/probe_basic/subroutines/clamptool.ngc
@@ -4,7 +4,7 @@ M65 P2 ; clamp the tool
 
 M66 P5 L3 Q1 ; check the clamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<clamptool> endsub [1]

--- a/configs/probe_basic/subroutines/extendatc.ngc
+++ b/configs/probe_basic/subroutines/extendatc.ngc
@@ -1,10 +1,16 @@
 o<extendatc> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/probe_basic/subroutines/extendatc.ngc
+++ b/configs/probe_basic/subroutines/extendatc.ngc
@@ -20,7 +20,7 @@ M64 P0 ; Move Carousel OUT
 M66 P1 L3 Q5 ; check for carousel out position sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 o<extendatc> endsub [1]

--- a/configs/probe_basic/subroutines/extendatc.ngc
+++ b/configs/probe_basic/subroutines/extendatc.ngc
@@ -1,6 +1,12 @@
 o<extendatc> sub
 
-G0 G53 Z0
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+
+#<atc_z_tool_change_height> = -3.9000
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 M65 P1 ; Turn off carousel home solenoid
 M64 P0 ; Move Carousel OUT

--- a/configs/probe_basic/subroutines/go_to_g30.ngc
+++ b/configs/probe_basic/subroutines/go_to_g30.ngc
@@ -1,5 +1,6 @@
 o<go_to_g30> sub
 
+M73
 G90
 G53 G0 Z0
 G30

--- a/configs/probe_basic/subroutines/go_to_home.ngc
+++ b/configs/probe_basic/subroutines/go_to_home.ngc
@@ -1,5 +1,6 @@
 o<go_to_home> sub
 
+M73
 G90
 G53 G0 Z0
 G53 G0 X0 Y0

--- a/configs/probe_basic/subroutines/go_to_zero.ngc
+++ b/configs/probe_basic/subroutines/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+M73
 G90
 o100 if [#5422 LT 0]
     G0 Z0

--- a/configs/probe_basic/subroutines/go_to_zero.ngc
+++ b/configs/probe_basic/subroutines/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+G90
 o100 if [#5422 LT 0]
     G0 Z0
     G0 X0 Y0

--- a/configs/probe_basic/subroutines/load_spindle_safety.ngc
+++ b/configs/probe_basic/subroutines/load_spindle_safety.ngc
@@ -12,7 +12,7 @@
 o<load_spindle_safety> sub
 (PRINT, o<load_spindle_safety>)
 
-#<load_spindle_tool_number> = #1
+#<load_spindle_tool_number> = #1 ; this is the value form the ATC tab
 #<activate_programmable_coolant> = #2
 #<horizontal_spindle_nozzle_dist> = #3
 #<vertical_spindle_nozzle_dist> = #4

--- a/configs/probe_basic/subroutines/load_spindle_safety_2.ngc
+++ b/configs/probe_basic/subroutines/load_spindle_safety_2.ngc
@@ -12,7 +12,7 @@
 o<load_spindle_safety_2> sub
 (PRINT, o<load_spindle_safety_2>)
 
-#<load_spindle_tool_number_2> = #1
+#<load_spindle_tool_number_2> = #1 ; this is the value form the TOOL tab
 #<activate_programmable_coolant> = #2
 #<horizontal_spindle_nozzle_dist> = #3
 #<vertical_spindle_nozzle_dist> = #4

--- a/configs/probe_basic/subroutines/m10.ngc
+++ b/configs/probe_basic/subroutines/m10.ngc
@@ -4,7 +4,7 @@ o<m10> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M10> P#<p>)
+(PRINT, o<m10> P#<p>)
 
 o100 if [#3989 NE 1]
     M13
@@ -17,7 +17,7 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
 o101 endif
 
 #<steps> = [#3990 - #<p>]
-(PRINT, o<M10> P#<p>, steps=#<steps>)
+(PRINT, o<m10> P#<p>, steps=#<steps>)
 o110 if [#<steps> GT [#<number_of_pockets> / 2]]
     #<steps>=[#<steps> - #<number_of_pockets>]
 o110 endif
@@ -31,6 +31,7 @@ o130 elseif [#<steps> LT 0]
     M11 P[#<steps>]
 o130 endif
 
+(PRINT, o<m10> endsub)
 o<m10> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m11.ngc
+++ b/configs/probe_basic/subroutines/m11.ngc
@@ -5,7 +5,7 @@ o<m11> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M11> P#<p>)
+(PRINT, o<m11> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P4 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990+2] MOD #<number_of_pockets>]-1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P4 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m11> endsub)
 o<m11> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m12.ngc
+++ b/configs/probe_basic/subroutines/m12.ngc
@@ -5,7 +5,7 @@ o<m12> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M12> P#<p>)
+(PRINT, o<m12> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P3 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990-2] MOD #<number_of_pockets>]+1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P3 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m12> endsub)
 o<m12> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m13.ngc
+++ b/configs/probe_basic/subroutines/m13.ngc
@@ -4,7 +4,7 @@ o<m13> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M13>)
+(PRINT, o<m13>)
 
 (DEBUG, EVAL[vcp.getWidget{"dynatc"}.atc_message{"REFERENCING"}])
 
@@ -12,7 +12,7 @@ M64 P3 ; Move Motor FWD
 M66 P3 L1 Q20 ; wait for rising edge on home index
 o100 if [#5399 LT 0]
     M65 P3 ; stop motor
-    (abort, failed to home carousel)
+    (abort, Failed to home carousel)
 o100 endif
 
 #3990 = 1
@@ -36,6 +36,7 @@ o120 endwhile
 
 M61 Q#3991 G43 H#3991 #5210 = 0
 
+(PRINT, o<m13> endsub)
 o<m13> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m13.ngc
+++ b/configs/probe_basic/subroutines/m13.ngc
@@ -9,7 +9,7 @@ o<m13> sub
 (DEBUG, EVAL[vcp.getWidget{"dynatc"}.atc_message{"REFERENCING"}])
 
 M64 P3 ; Move Motor FWD
-M66 P3 L1 Q20 ; wait for rising edge on rotation index
+M66 P3 L1 Q20 ; wait for rising edge on home index
 o100 if [#5399 LT 0]
     M65 P3 ; stop motor
     (abort, failed to home carousel)

--- a/configs/probe_basic/subroutines/m21.ngc
+++ b/configs/probe_basic/subroutines/m21.ngc
@@ -5,7 +5,7 @@ o<m21> sub
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M21>)
+(PRINT, o<m21>)
 
 #<atc_z_tool_change_height> = -3.1900
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -29,7 +29,7 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 M24 ; activate drawbar, release the tool
@@ -39,6 +39,7 @@ G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 #3991 = 0; save fact there is now no tool in the spindle
 
+(PRINT, o<m21> endsub)
 o<m21> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m21.ngc
+++ b/configs/probe_basic/subroutines/m21.ngc
@@ -3,12 +3,18 @@ o<m21> sub
 ; Move Carousel to the tool change position - OUT
 ; then unload any tool in the spindle into the current pocket
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.1900
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/probe_basic/subroutines/m21.ngc
+++ b/configs/probe_basic/subroutines/m21.ngc
@@ -8,7 +8,7 @@ o<m21> sub
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/probe_basic/subroutines/m22.ngc
+++ b/configs/probe_basic/subroutines/m22.ngc
@@ -2,12 +2,18 @@ o<m22> sub
 
 ; Move Carousel to the home position - IN
 ; after loading any tool in the current pocket to the spindle
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.1900
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 ;M19 R0 Q2
 M24

--- a/configs/probe_basic/subroutines/m22.ngc
+++ b/configs/probe_basic/subroutines/m22.ngc
@@ -4,7 +4,7 @@ o<m22> sub
 ; after loading any tool in the current pocket to the spindle
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M22>)
+(PRINT, o<m22>)
 
 #<atc_z_tool_change_height> = -3.1900
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -24,18 +24,19 @@ M65 P2 ; release the drawbar to clamp the tool
 M5
 M66 P5 L3 Q1 ; check the tool clamped sensor
 o100 if [#5399 LT 0]
-    (abort, failed to reclamp tool)
+    (abort, Failed to reclamp tool)
 o100 endif
 
 M65 P0 ; Move Carousel home
 M66 P0 L3 Q4 ; check carousel in position sensor
 o110 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o110 endif
 
 ;M65 P1
 
+(PRINT, o<m22> endsub)
 o<m22> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m22.ngc
+++ b/configs/probe_basic/subroutines/m22.ngc
@@ -7,7 +7,7 @@ o<m22> sub
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 ;M19 R0 Q2
 M24

--- a/configs/probe_basic/subroutines/m24.ngc
+++ b/configs/probe_basic/subroutines/m24.ngc
@@ -2,12 +2,13 @@ o<m24> sub
 (PRINT, o<m24>)
 
 M64 P2 ; unclamp the tool
-M66 P2 L3 Q3 ; check the unclamped tool sensor
+M66 P2 L3 Q2 ; check the unclamped tool sensor
 o100 if [#5399 LT 0]
     M65 P2 ; turn off the drawbar
     (abort, failed to release tool) ; abort if the sensor does not activate in 3 seconds
 o100 endif
 
+(PRINT, o<m24> endsub)
 o<m24> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m25.ngc
+++ b/configs/probe_basic/subroutines/m25.ngc
@@ -6,9 +6,10 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
+(PRINT, o<m25> endsub)
 o<m25> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/m25.ngc
+++ b/configs/probe_basic/subroutines/m25.ngc
@@ -2,6 +2,7 @@ o<m25> sub
 (PRINT, o<m25>)
 
 M64 P0 ; Move Carousel out
+
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid

--- a/configs/probe_basic/subroutines/move_head_above_carousel.ngc
+++ b/configs/probe_basic/subroutines/move_head_above_carousel.ngc
@@ -1,10 +1,16 @@
 o<move_head_above_carousel> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
 #<atc_z_tool_change_height> = -3.1900
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/probe_basic/subroutines/move_head_above_carousel.ngc
+++ b/configs/probe_basic/subroutines/move_head_above_carousel.ngc
@@ -4,7 +4,7 @@ o<move_head_above_carousel> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/probe_basic/subroutines/move_tool_to_carousel_height.ngc
+++ b/configs/probe_basic/subroutines/move_tool_to_carousel_height.ngc
@@ -3,7 +3,7 @@ o<move_tool_to_carousel_height> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/probe_basic/subroutines/move_tool_to_carousel_height.ngc
+++ b/configs/probe_basic/subroutines/move_tool_to_carousel_height.ngc
@@ -1,9 +1,15 @@
 o<move_tool_to_carousel_height> sub
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
 #<atc_z_tool_change_height> = -3.1900
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/probe_basic/subroutines/probe_top_right_edge_angle.ngc
+++ b/configs/probe_basic/subroutines/probe_top_right_edge_angle.ngc
@@ -7,7 +7,7 @@
 (step off width distance and within max z distance)
 (ensure all settings have been set properly according to help diagrams)
 
-o<Probe_top_right_edge_angle> sub
+o<probe_top_right_edge_angle> sub
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)
@@ -37,7 +37,7 @@ o<Probe_top_right_edge_angle> sub
   (Probe Tool Safety Check)
   o100 if [#5400 NE #<probe_tool_number>]
      (MSG, Specified probe tool #<probe_tool_number> not in spindle, aborting)
-     o<Probe_top_right_edge_angle> return
+     o<probe_top_right_edge_angle> return
   o100 endif
 
   (Probe Diameter)
@@ -68,7 +68,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o110 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o110 endif
 
   (edge width move to edge second probing point)
@@ -84,7 +84,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o120 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o120 endif
 
   #<edge_delta> = [#<x_minus_zero_edge_start> - #<x_minus_zero_edge_end>]
@@ -109,16 +109,16 @@ o<Probe_top_right_edge_angle> sub
   o130 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 0]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o130 endif
 
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o140 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o140 endif
 
-o<Probe_top_right_edge_angle> endsub
+o<probe_top_right_edge_angle> endsub
 
 M2 (end program)

--- a/configs/probe_basic/subroutines/retractatc.ngc
+++ b/configs/probe_basic/subroutines/retractatc.ngc
@@ -6,7 +6,7 @@ M64 P1 ; Move Carousel IN
 M66 P0 L3 Q4 ; check carousel in position sensor
 o100 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o100 endif
 M65 P1
 

--- a/configs/probe_basic/subroutines/tool_touch_off.ngc
+++ b/configs/probe_basic/subroutines/tool_touch_off.ngc
@@ -1,5 +1,7 @@
 o<tool_touch_off> sub
 
+; NOTE this routine used G59.3, and this needs to be set to 0,0,0 for everything to work correctly
+
 #<fast_probe_fr> = #1    (set from probe screen fast probe feed rate)
 #<slow_probe_fr> = #2    (set from probe screen slow probe feedrate)
 #<z_max_travel> = #3    (max z distance the tool travels before erroring out if not contact is made)

--- a/configs/probe_basic/subroutines/toolchange.ngc
+++ b/configs/probe_basic/subroutines/toolchange.ngc
@@ -6,8 +6,10 @@ o<toolchange> sub
 ; Parameters #4001 to #4024 are used to track which tool is in which pocket (persistently)
 ; Parameter #4000 is not populated just used in the maths to calculate the above numbers
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-(PRINT, o<toolchange>)
+(PRINT, o<toolchange> selected_tool: #<selected_tool>, tool_in_spindle: #<tool_in_spindle>, selected_pocket: #<selected_pocket>, current_pocket: #<current_pocket>, task: #<_task>)
 
 o100 if [#<_task> EQ 0]
     (DEBUG, Task is null)
@@ -20,28 +22,46 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
     #<number_of_pockets> = #<_ini[atc]pockets>
 o101 endif
 
+#<atc_z_tool_change_height> = -3.1900
+o102 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o102 endif
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o103 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o103 endif
+
 ; assign the programmable coolant parameters
 #<activate_programmable_coolant> = #1 (=0)
 #<horizontal_spindle_nozzle_dist> = #2 (=0)
 #<vertical_spindle_nozzle_dist> = #3 (=0)
 #<pc_angle_offset> = #4 (=0)
 
-; assign the variables passed by M6 to some parameters
+; assign the variables passed by M6 change_prolog to some parameters
 #100 = #<selected_tool>
 #110 = #<tool_in_spindle>
 #120 = #<selected_pocket>
+#121 = #<current_pocket>
+; NOTE:
+;      The legacy names *selected_pocket* and *current_pocket* actually reference
+;      a sequential tooldata index for tool items loaded from a tool
+;      table ([EMCIO]TOOL_TABLE) or via a tooldata database ([EMCIO]DB_PROGRAM)
 
-o110 if [#100 EQ #110] ; checks if tool in the spindle is same as requested
+o110 if [#<selected_tool> EQ #<tool_in_spindle>] ; checks if tool in the spindle is same as requested
     o<toolchange> endsub [1]
     M2
 o110 endif
+
+o111 if [#3991 NE #<tool_in_spindle>]
+    (PRINT, o<toolchange> tool_in_spindle does not match 3991)
+o111 endif
 
 #<next_pocket> = 0 ; assigns 0 to the next pocket for a later check if the tool is found in the carousel
 #<open_pocket> = 0
 #130 = #<number_of_pockets> ; assign test parameter the number of pockets in the carousel
 
 o120 do
-    o121 if [#[4000 + #130] EQ #100] ; checks all pockets to see if it contains tool number requested as the new tool
+    o121 if [#[4000 + #130] EQ #<selected_tool>] ; checks all pockets to see if it contains tool number requested as the new tool
         #<next_pocket> = #130 ; if tool is found in pocket, assigns the next pocket
     o121 endif
     o122 if [#[4000 + #130] EQ 0] ; checks if the pocket is empty, last pocket checked will be the lowest empty pocket number, for putting tool in spindle away.
@@ -50,7 +70,7 @@ o120 do
     #130 = [#130 - 1]
 o120 while [#130 GT 0]
 o130 if [#<next_pocket> EQ 0] ; if tool is not found, aborts and sends a message
-    (abort, tool not in carousel)
+    (abort, Tool T%d#<selected_tool> not found in carousel)
 o130 endif
 
 ; now we know which pocket the next tool is sitting in
@@ -59,7 +79,7 @@ o130 endif
 
 o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spindle
     o141 if [#<open_pocket> EQ 0] ; If there is a tool in the spindle, checks if there is an open pocket
-        (abort, carousel is full, cant put away tool in into carousel)
+        (abort, Carousel is full, cant put away tool T#<tool_in_spindle> in into carousel)
     o141 endif
     M10 P[#<open_pocket>] ; move carousel to an open pocket
     M21 ; puts the tool in spindle away into the open pocket
@@ -67,10 +87,12 @@ o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spind
     #140 = #<open_pocket>
     #[4000 + #140] = #<tool_in_spindle> ; save tool number in pocket
     #3991 = 0 ; empty tool in the spindle
+    M61 Q0
+    G49
 o140 endif
 
 G90
-G0 G53 Z0
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M10 P#<next_pocket> ; set the carousel to move to the right pocket for the selected tool
@@ -79,7 +101,7 @@ o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M66 P1 L3 Q5 ; check carousel out position sensor
     o151 if [#5399 LT 0]
         M65 P0 ; turn off the solenoid to send atc to tool change
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o151 endif
     M65 P0
 
@@ -95,7 +117,7 @@ o150 else
     M66 P0 L3 Q4 ; check carousel in position sensor
     o152 if [#5399 LT 0]
         M65 P1 ; turn off the solenoid to send atc home
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o152 endif
     M65 P1
 o150 endif
@@ -112,6 +134,7 @@ o170 if [#<activate_programmable_coolant> EQ 1]
     o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
 o170 endif
 
+(PRINT, o<toolchange> endsub)
 o<toolchange> endsub [1]
 
 M2

--- a/configs/probe_basic/subroutines/unclamptool.ngc
+++ b/configs/probe_basic/subroutines/unclamptool.ngc
@@ -4,7 +4,7 @@ M64 P2 ; unclamp the tool
 
 M66 P2 L3 Q2 ; check the unclamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<unclamptool> endsub [1]

--- a/configs/probe_basic_lathe/subroutines/clamptool.ngc
+++ b/configs/probe_basic_lathe/subroutines/clamptool.ngc
@@ -4,7 +4,7 @@ M65 P2 ; clamp the tool
 
 M66 P5 L3 Q2 ; check the clamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<clamptool> endsub [1]

--- a/configs/probe_basic_lathe/subroutines/extendatc.ngc
+++ b/configs/probe_basic_lathe/subroutines/extendatc.ngc
@@ -1,10 +1,16 @@
 o<extendatc> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/probe_basic_lathe/subroutines/extendatc.ngc
+++ b/configs/probe_basic_lathe/subroutines/extendatc.ngc
@@ -20,7 +20,7 @@ M64 P0 ; Move Carousel OUT
 M66 P1 L3 Q5 ; check for carousel out position sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 o<extendatc> endsub [1]

--- a/configs/probe_basic_lathe/subroutines/extendatc.ngc
+++ b/configs/probe_basic_lathe/subroutines/extendatc.ngc
@@ -1,6 +1,12 @@
 o<extendatc> sub
 
-G0 G53 Z0
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+
+#<atc_z_tool_change_height> = -3.9000
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 M65 P1 ; Turn off carousel home solenoid
 M64 P0 ; Move Carousel OUT

--- a/configs/probe_basic_lathe/subroutines/go_to_g30.ngc
+++ b/configs/probe_basic_lathe/subroutines/go_to_g30.ngc
@@ -1,4 +1,5 @@
 o<go_to_g30> sub
+; Lathe specific version
 
 M73
 G90

--- a/configs/probe_basic_lathe/subroutines/go_to_g30.ngc
+++ b/configs/probe_basic_lathe/subroutines/go_to_g30.ngc
@@ -1,5 +1,6 @@
 o<go_to_g30> sub
 
+M73
 G90
 G30
 

--- a/configs/probe_basic_lathe/subroutines/go_to_home.ngc
+++ b/configs/probe_basic_lathe/subroutines/go_to_home.ngc
@@ -1,5 +1,6 @@
 o<go_to_home> sub
 
+M73
 G90
 G53 G0 Z0
 G53 G0 X0

--- a/configs/probe_basic_lathe/subroutines/go_to_home.ngc
+++ b/configs/probe_basic_lathe/subroutines/go_to_home.ngc
@@ -1,4 +1,5 @@
 o<go_to_home> sub
+; Lathe specific version
 
 M73
 G90

--- a/configs/probe_basic_lathe/subroutines/go_to_zero.ngc
+++ b/configs/probe_basic_lathe/subroutines/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+G90
 o100 if [#5422 LT 0]
     G0 Z0
     G0 X0

--- a/configs/probe_basic_lathe/subroutines/go_to_zero.ngc
+++ b/configs/probe_basic_lathe/subroutines/go_to_zero.ngc
@@ -1,4 +1,5 @@
 o<go_to_zero> sub
+; Lathe specific version
 
 M73
 G90

--- a/configs/probe_basic_lathe/subroutines/go_to_zero.ngc
+++ b/configs/probe_basic_lathe/subroutines/go_to_zero.ngc
@@ -1,5 +1,6 @@
 o<go_to_zero> sub
 
+M73
 G90
 o100 if [#5422 LT 0]
     G0 Z0

--- a/configs/probe_basic_lathe/subroutines/m10.ngc
+++ b/configs/probe_basic_lathe/subroutines/m10.ngc
@@ -4,7 +4,7 @@ o<m10> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M10> P#<p>)
+(PRINT, o<m10> P#<p>)
 
 o100 if [#3989 NE 1]
     M13
@@ -17,7 +17,7 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
 o101 endif
 
 #<steps> = [#3990 - #<p>]
-(PRINT, o<M10> P#<p>, steps=#<steps>)
+(PRINT, o<m10> P#<p>, steps=#<steps>)
 o110 if [#<steps> GT [#<number_of_pockets> / 2]]
     #<steps>=[#<steps> - #<number_of_pockets>]
 o110 endif
@@ -31,6 +31,7 @@ o130 elseif [#<steps> LT 0]
     M11 P[#<steps>]
 o130 endif
 
+(PRINT, o<m10> endsub)
 o<m10> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m11.ngc
+++ b/configs/probe_basic_lathe/subroutines/m11.ngc
@@ -5,7 +5,7 @@ o<m11> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M11> P#<p>)
+(PRINT, o<m11> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P4 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990+2] MOD #<number_of_pockets>]-1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P4 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m11> endsub)
 o<m11> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m12.ngc
+++ b/configs/probe_basic_lathe/subroutines/m12.ngc
@@ -5,7 +5,7 @@ o<m12> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M12> P#<p>)
+(PRINT, o<m12> P#<p>)
 
 o100 if [#3989 NE 1]
     (PRINT, atc not homed, homing)
@@ -34,7 +34,7 @@ o120 do
     M66 P4 L1 Q3 ; wait for rising edge on rotation index
     o130 if [#5399 LT 0]
         M65 P3 ; Stop atc motor
-        (abort, failed to get rotation index)
+        (abort, Failed to get rotation index)
     o130 endif
     #3990 = [[[#3990-2] MOD #<number_of_pockets>]+1] ; Pocket is no.1-#<number_of_pockets>
     #<steps_to_move> = [#<steps_to_move>-1]
@@ -44,6 +44,7 @@ M65 P3 ; Stop motor
 
 #<_my_current_pocket> = #3990
 
+(PRINT, o<m12> endsub)
 o<m12> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m13.ngc
+++ b/configs/probe_basic_lathe/subroutines/m13.ngc
@@ -4,7 +4,7 @@ o<m13> sub
 ; Parameter #3989 is used to track if the carousel is homed (M13) (volatile)
 ; Parameter #3990 is used to track the current tool pocket (persistently)
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
-(PRINT, o<M13>)
+(PRINT, o<m13>)
 
 (DEBUG, EVAL[vcp.getWidget{"dynatc"}.atc_message{"REFERENCING"}])
 
@@ -12,7 +12,7 @@ M64 P3 ; Move Motor FWD
 M66 P3 L1 Q20 ; wait for rising edge on home index
 o100 if [#5399 LT 0]
     M65 P3 ; stop motor
-    (abort, failed to home carousel)
+    (abort, Failed to home carousel)
 o100 endif
 
 #3990 = 1
@@ -36,6 +36,7 @@ o120 endwhile
 
 M61 Q#3991 G43 H#3991 #5210 = 0
 
+(PRINT, o<m13> endsub)
 o<m13> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m13.ngc
+++ b/configs/probe_basic_lathe/subroutines/m13.ngc
@@ -9,7 +9,7 @@ o<m13> sub
 (DEBUG, EVAL[vcp.getWidget{"dynatc"}.atc_message{"REFERENCING"}])
 
 M64 P3 ; Move Motor FWD
-M66 P3 L1 Q20 ; wait for rising edge on rotation index
+M66 P3 L1 Q20 ; wait for rising edge on home index
 o100 if [#5399 LT 0]
     M65 P3 ; stop motor
     (abort, failed to home carousel)

--- a/configs/probe_basic_lathe/subroutines/m21.ngc
+++ b/configs/probe_basic_lathe/subroutines/m21.ngc
@@ -8,7 +8,7 @@ o<m21> sub
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.9000
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/probe_basic_lathe/subroutines/m21.ngc
+++ b/configs/probe_basic_lathe/subroutines/m21.ngc
@@ -3,12 +3,18 @@ o<m21> sub
 ; Move Carousel to the tool change position - OUT
 ; then unload any tool in the spindle into the current pocket
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M21>)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 M65 P1 ; switch off carousel in solenoid
 M66 P1 L3 Q1

--- a/configs/probe_basic_lathe/subroutines/m21.ngc
+++ b/configs/probe_basic_lathe/subroutines/m21.ngc
@@ -5,7 +5,7 @@ o<m21> sub
 ; Parameter #3991 is used to track the current tool loaded it in the spindle (persistently)
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M21>)
+(PRINT, o<m21>)
 
 #<atc_z_tool_change_height> = -3.9000
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -29,7 +29,7 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
 M24 ; activate drawbar, release the tool
@@ -39,6 +39,7 @@ G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 #3991 = 0; save fact there is now no tool in the spindle
 
+(PRINT, o<m21> endsub)
 o<m21> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m22.ngc
+++ b/configs/probe_basic_lathe/subroutines/m22.ngc
@@ -7,7 +7,7 @@ o<m22> sub
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.9000
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 ;M19 R0 Q2
 M24

--- a/configs/probe_basic_lathe/subroutines/m22.ngc
+++ b/configs/probe_basic_lathe/subroutines/m22.ngc
@@ -2,12 +2,18 @@ o<m22> sub
 
 ; Move Carousel to the home position - IN
 ; after loading any tool in the current pocket to the spindle
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 (PRINT, o<M22>)
 
 #<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 ;M19 R0 Q2
 M24

--- a/configs/probe_basic_lathe/subroutines/m22.ngc
+++ b/configs/probe_basic_lathe/subroutines/m22.ngc
@@ -4,7 +4,7 @@ o<m22> sub
 ; after loading any tool in the current pocket to the spindle
 ; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
-(PRINT, o<M22>)
+(PRINT, o<m22>)
 
 #<atc_z_tool_change_height> = -3.9000
 o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
@@ -24,18 +24,19 @@ M65 P2 ; release the drawbar to clamp the tool
 M5
 M66 P5 L3 Q1 ; check the tool clamped sensor
 o100 if [#5399 LT 0]
-    (abort, failed to reclamp tool)
+    (abort, Failed to reclamp tool)
 o100 endif
 
 M65 P0 ; Move Carousel home
 M66 P0 L3 Q4 ; check carousel in position sensor
 o110 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o110 endif
 
 ;M65 P1
 
+(PRINT, o<m22> endsub)
 o<m22> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m24.ngc
+++ b/configs/probe_basic_lathe/subroutines/m24.ngc
@@ -2,12 +2,13 @@ o<m24> sub
 (PRINT, o<m24>)
 
 M64 P2 ; unclamp the tool
-M66 P2 L3 Q3 ; check the unclamped tool sensor
+M66 P2 L3 Q2 ; check the unclamped tool sensor
 o100 if [#5399 LT 0]
     M65 P2 ; turn off the drawbar
     (abort, failed to release tool) ; abort if the sensor does not activate in 3 seconds
 o100 endif
 
+(PRINT, o<m24> endsub)
 o<m24> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m25.ngc
+++ b/configs/probe_basic_lathe/subroutines/m25.ngc
@@ -6,9 +6,10 @@ M64 P0 ; Move Carousel out
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid
-    (abort, atc not in position)
+    (abort, ATC not in position)
 o100 endif
 
+(PRINT, o<m25> endsub)
 o<m25> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/m25.ngc
+++ b/configs/probe_basic_lathe/subroutines/m25.ngc
@@ -2,6 +2,7 @@ o<m25> sub
 (PRINT, o<m25>)
 
 M64 P0 ; Move Carousel out
+
 M66 P1 L3 Q5 ; check for carousel out sensor
 o100 if [#5399 LT 0]
     M65 P0 ; switch off atc out solenoid

--- a/configs/probe_basic_lathe/subroutines/m6_tool_call_main_panel.ngc
+++ b/configs/probe_basic_lathe/subroutines/m6_tool_call_main_panel.ngc
@@ -5,6 +5,7 @@
 (m6 tool call with g43 offset applied)
 
 o<m6_tool_call_main_panel> sub
+; Lathe specific version
 
 #<tool_number_entry_main_panel> = #1
 #<x_tool_change_position> = #2

--- a/configs/probe_basic_lathe/subroutines/m6_tool_call_touch_panel.ngc
+++ b/configs/probe_basic_lathe/subroutines/m6_tool_call_touch_panel.ngc
@@ -4,7 +4,7 @@
 
 (m6 tool call with g43 offset applied)
 
-o<M6_tool_call_touch_panel> sub
+o<m6_tool_call_touch_panel> sub
 
 #<tool_number_entry_touch_panel> = #1
 #<x_tool_change_position> = #2
@@ -19,7 +19,7 @@ o100 if [#<use_tcp_mode> EQ 1]
   G90
   G53 G0 Z#<z_tool_change_position>
   G53 G0 X#<x_tool_change_position>
-  o<M6_tool_call_touch_panel> return
+  o<m6_tool_call_touch_panel> return
 o100 endif
 
 T#<tool_number_entry_touch_panel> M6 g43

--- a/configs/probe_basic_lathe/subroutines/move_head_above_carousel.ngc
+++ b/configs/probe_basic_lathe/subroutines/move_head_above_carousel.ngc
@@ -1,10 +1,17 @@
 o<move_head_above_carousel> sub
 
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-#<atc_z_tool_change_height> = -3.1900
+#<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
+
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/probe_basic_lathe/subroutines/move_head_above_carousel.ngc
+++ b/configs/probe_basic_lathe/subroutines/move_head_above_carousel.ngc
@@ -4,7 +4,7 @@ o<move_head_above_carousel> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 

--- a/configs/probe_basic_lathe/subroutines/move_tool_to_carousel_height.ngc
+++ b/configs/probe_basic_lathe/subroutines/move_tool_to_carousel_height.ngc
@@ -1,9 +1,15 @@
 o<move_tool_to_carousel_height> sub
-; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (adjust to your needs)
-; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-#<atc_z_tool_change_height> = -3.1900
+#<atc_z_tool_change_height> = -3.9000
+o101 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o101 endif
 #<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o102 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o102 endif
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/probe_basic_lathe/subroutines/move_tool_to_carousel_height.ngc
+++ b/configs/probe_basic_lathe/subroutines/move_tool_to_carousel_height.ngc
@@ -3,7 +3,7 @@ o<move_tool_to_carousel_height> sub
 ; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (adjust to your needs)
 
 #<atc_z_tool_change_height> = -3.1900
-#<atc_z_tool_clearance_height> = 0
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
 
 G0 G53 Z#<atc_z_tool_change_height> ; rapid move to above the tool change height
 

--- a/configs/probe_basic_lathe/subroutines/probe_corner_x_minus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_x_minus_edge_angle.ngc
@@ -8,6 +8,7 @@
 (ensure all settings have been set properly according to help diagrams)
 
 o<probe_corner_x_minus_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)

--- a/configs/probe_basic_lathe/subroutines/probe_corner_x_plus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_x_plus_edge_angle.ngc
@@ -8,6 +8,7 @@
 (ensure all settings have been set properly according to help diagrams)
 
 o<probe_corner_x_plus_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)

--- a/configs/probe_basic_lathe/subroutines/probe_corner_y_minus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_y_minus_edge_angle.ngc
@@ -8,6 +8,7 @@
 (ensure all settings have been set properly according to help diagrams)
 
 o<probe_corner_y_minus_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)

--- a/configs/probe_basic_lathe/subroutines/probe_corner_y_plus_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_corner_y_plus_edge_angle.ngc
@@ -8,6 +8,7 @@
 (ensure all settings have been set properly according to help diagrams)
 
 o<probe_corner_y_plus_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)

--- a/configs/probe_basic_lathe/subroutines/probe_top_back_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_back_edge_angle.ngc
@@ -8,6 +8,7 @@
 (ensure all settings have been set properly according to help diagrams)
 
 o<probe_top_back_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)

--- a/configs/probe_basic_lathe/subroutines/probe_top_front_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_front_edge_angle.ngc
@@ -8,6 +8,7 @@
 (ensure all settings have been set properly according to help diagrams)
 
 o<probe_top_front_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)

--- a/configs/probe_basic_lathe/subroutines/probe_top_left_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_left_edge_angle.ngc
@@ -8,6 +8,7 @@
 (ensure all settings have been set properly according to help diagrams)
 
 o<probe_top_left_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)

--- a/configs/probe_basic_lathe/subroutines/probe_top_right_edge_angle.ngc
+++ b/configs/probe_basic_lathe/subroutines/probe_top_right_edge_angle.ngc
@@ -7,7 +7,8 @@
 (step off width distance and within max z distance)
 (ensure all settings have been set properly according to help diagrams)
 
-o<Probe_top_right_edge_angle> sub
+o<probe_top_right_edge_angle> sub
+; Lathe specific version
 
   (uses NGCGUI style arg spec)
   (number after "=" in comment is default value)
@@ -38,7 +39,7 @@ o<Probe_top_right_edge_angle> sub
   (Probe Tool Safety Check)
   o100 if [#5400 NE #<probe_tool_number>]
      (MSG, Specified probe tool #<probe_tool_number> not in spindle, aborting)
-     o<Probe_top_right_edge_angle> return
+     o<probe_top_right_edge_angle> return
   o100 endif
 
   (Probe Diameter)
@@ -69,7 +70,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o110 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o110 endif
 
   (edge width move to edge second probing point)
@@ -85,7 +86,7 @@ o<Probe_top_right_edge_angle> sub
   (value returned safety check, aborts if no value returned)
   o120 if [#<probe_mode> EQ 1 AND #<_value_returned> NE 1]
       (MSG, Missing X Sub returned edge parameter, aborting)
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o120 endif
 
   #<edge_delta> = [#<x_minus_zero_edge_start> - #<x_minus_zero_edge_end>]
@@ -110,16 +111,16 @@ o<Probe_top_right_edge_angle> sub
   o130 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 0]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o130 endif
 
   (probe mode rules for WCO, Rotation and probe position measuring only)
   o140 if [#<probe_mode> EQ 0 AND #<wco_rotation> EQ 1]
       (Record Zero in selected axes and WCO)
       G10 L2 P#5220 X[#<x_minus_zero_edge_start> + #<workspace_x>] Y[#<y_start_position>] R[#<edge_angle> + #<workspace_r>]
-      o<Probe_top_right_edge_angle> return
+      o<probe_top_right_edge_angle> return
   o140 endif
 
-o<Probe_top_right_edge_angle> endsub
+o<probe_top_right_edge_angle> endsub
 
 M2 (end program)

--- a/configs/probe_basic_lathe/subroutines/retractatc.ngc
+++ b/configs/probe_basic_lathe/subroutines/retractatc.ngc
@@ -6,7 +6,7 @@ M64 P1 ; Move Carousel IN
 M66 P0 L3 Q5 ; check carousel in position sensor
 o100 if [#5399 LT 0]
     M65 P1 ; turn off the solenoid to send atc home
-    (abort, failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
+    (abort, Failed to send carousel home) ; abort if the sensor does not activate in 5 seconds
 o100 endif
 M65 P1
 

--- a/configs/probe_basic_lathe/subroutines/set_g30_position.ngc
+++ b/configs/probe_basic_lathe/subroutines/set_g30_position.ngc
@@ -1,4 +1,5 @@
 o<set_g30_position> sub
+; Lathe specific version
 
 o100 if [1 EQ 1]
     (G30.1 records the tool touch off position in the var file)

--- a/configs/probe_basic_lathe/subroutines/tool_touch_off.ngc
+++ b/configs/probe_basic_lathe/subroutines/tool_touch_off.ngc
@@ -1,5 +1,7 @@
 o<tool_touch_off> sub
 
+; NOTE this routine used G59.3, and this needs to be set to 0,0,0 for everything to work correctly
+
 #<fast_probe_fr> = #1    (set from probe screen fast probe feed rate)
 #<slow_probe_fr> = #2    (set from probe screen slow probe feedrate)
 #<z_max_travel> = #3    (max z distance the tool travels before erroring out if not contact is made)

--- a/configs/probe_basic_lathe/subroutines/toolchange.ngc
+++ b/configs/probe_basic_lathe/subroutines/toolchange.ngc
@@ -6,8 +6,10 @@ o<toolchange> sub
 ; Parameters #4001 to #4024 are used to track which tool is in which pocket (persistently)
 ; Parameter #4000 is not populated just used in the maths to calculate the above numbers
 ; #<number_of_pockets>: The number of pockets in the ATC is automaticity pulled from the INI via #<_ini[atc]pockets>
+; #<atc_z_tool_change_height> is the height you spindle needs to be at to clamp/unclamp a tool form the ATC (Set via INI [ATC]Z_TOOL_CHANGE_HEIGHT)
+; #<atc_z_tool_clearance_height> is the clearance height you spindle needs to be at to safely clear the ATC (Set via INI [ATC]Z_TOOL_CLEARANCE_HEIGHT)
 
-(PRINT, o<toolchange>)
+(PRINT, o<toolchange> selected_tool: #<selected_tool>, tool_in_spindle: #<tool_in_spindle>, selected_pocket: #<selected_pocket>, current_pocket: #<current_pocket>, task: #<_task>)
 
 o100 if [#<_task> EQ 0]
     (DEBUG, Task is null)
@@ -20,28 +22,46 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
     #<number_of_pockets> = #<_ini[atc]pockets>
 o101 endif
 
+#<atc_z_tool_change_height> = -3.9000
+o102 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
+    #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
+o102 endif
+#<atc_z_tool_clearance_height> = [#<_ini[AXIS_Z]MAX_LIMIT>-0.1]
+o103 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
+    #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
+o103 endif
+
 ; assign the programmable coolant parameters
 #<activate_programmable_coolant> = #1 (=0)
 #<horizontal_spindle_nozzle_dist> = #2 (=0)
 #<vertical_spindle_nozzle_dist> = #3 (=0)
 #<pc_angle_offset> = #4 (=0)
 
-; assign the variables passed by M6 to some parameters
+; assign the variables passed by M6 change_prolog to some parameters
 #100 = #<selected_tool>
 #110 = #<tool_in_spindle>
 #120 = #<selected_pocket>
+#121 = #<current_pocket>
+; NOTE:
+;      The legacy names *selected_pocket* and *current_pocket* actually reference
+;      a sequential tooldata index for tool items loaded from a tool
+;      table ([EMCIO]TOOL_TABLE) or via a tooldata database ([EMCIO]DB_PROGRAM)
 
-o110 if [#100 EQ #110] ; checks if tool in the spindle is same as requested
+o110 if [#<selected_tool> EQ #<tool_in_spindle>] ; checks if tool in the spindle is same as requested
     o<toolchange> endsub [1]
     M2
 o110 endif
+
+o111 if [#3991 NE #<tool_in_spindle>]
+    (PRINT, o<toolchange> tool_in_spindle does not match 3991)
+o111 endif
 
 #<next_pocket> = 0 ; assigns 0 to the next pocket for a later check if the tool is found in the carousel
 #<open_pocket> = 0
 #130 = #<number_of_pockets> ; assign test parameter the number of pockets in the carousel
 
 o120 do
-    o121 if [#[4000 + #130] EQ #100] ; checks all pockets to see if it contains tool number requested as the new tool
+    o121 if [#[4000 + #130] EQ #<selected_tool>] ; checks all pockets to see if it contains tool number requested as the new tool
         #<next_pocket> = #130 ; if tool is found in pocket, assigns the next pocket
     o121 endif
     o122 if [#[4000 + #130] EQ 0] ; checks if the pocket is empty, last pocket checked will be the lowest empty pocket number, for putting tool in spindle away.
@@ -50,7 +70,7 @@ o120 do
     #130 = [#130 - 1]
 o120 while [#130 GT 0]
 o130 if [#<next_pocket> EQ 0] ; if tool is not found, aborts and sends a message
-    (abort, tool not in carousel)
+    (abort, Tool T%d#<selected_tool> not found in carousel)
 o130 endif
 
 ; now we know which pocket the next tool is sitting in
@@ -59,7 +79,7 @@ o130 endif
 
 o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spindle
     o141 if [#<open_pocket> EQ 0] ; If there is a tool in the spindle, checks if there is an open pocket
-        (abort, carousel is full, cant put away tool in into carousel)
+        (abort, Carousel is full, cant put away tool T#<tool_in_spindle> in into carousel)
     o141 endif
     M10 P[#<open_pocket>] ; move carousel to an open pocket
     M21 ; puts the tool in spindle away into the open pocket
@@ -67,10 +87,12 @@ o140 if [#<tool_in_spindle> GT 0] ; checks if there is a valid tool in the spind
     #140 = #<open_pocket>
     #[4000 + #140] = #<tool_in_spindle> ; save tool number in pocket
     #3991 = 0 ; empty tool in the spindle
+    M61 Q0
+    G49
 o140 endif
 
 G90
-G0 G53 Z0
+G0 G53 Z#<atc_z_tool_clearance_height> ; move z to clear height
 
 o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M10 P#<next_pocket> ; set the carousel to move to the right pocket for the selected tool
@@ -79,7 +101,7 @@ o150 if [#<selected_tool> GT 0] ; selected tool is not tool0
     M66 P1 L3 Q5 ; check carousel out position sensor
     o151 if [#5399 LT 0]
         M65 P0 ; turn off the solenoid to send atc to tool change
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o151 endif
     M65 P0
 
@@ -95,7 +117,7 @@ o150 else
     M66 P0 L3 Q4 ; check carousel in position sensor
     o152 if [#5399 LT 0]
         M65 P1 ; turn off the solenoid to send atc home
-        (abort, failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
+        (abort, Failed to send carousel home) ; abort if the    sensor does not activate in 5 seconds
     o152 endif
     M65 P1
 o150 endif
@@ -112,6 +134,7 @@ o170 if [#<activate_programmable_coolant> EQ 1]
     o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
 o170 endif
 
+(PRINT, o<toolchange> endsub)
 o<toolchange> endsub [1]
 
 M2

--- a/configs/probe_basic_lathe/subroutines/unclamptool.ngc
+++ b/configs/probe_basic_lathe/subroutines/unclamptool.ngc
@@ -4,7 +4,7 @@ M64 P2 ; unclamp the tool
 
 M66 P2 L3 Q2 ; check the unclamped tool sensor
 o100 if [#5399 LT 0]
-    (abort, failed to release tool) ; abort if the sensor does not activate in 2 seconds
+    (abort, Failed to release tool) ; abort if the sensor does not activate in 2 seconds
 o100 endif
 
 o<unclamptool> endsub [1]


### PR DESCRIPTION
Back-porting some style tweaks and abort message improvements from #100 

Big user-friendly change is to the dreaded 
```
(abort, tool not in carousel)
```

It now at least include the T number of the tool its is trying to fetch
```
(abort, Tool T%d#<selected_tool> not found in carousel)
```

This also allows `#<atc_z_tool_change_height>` and `#<atc_z_tool_clearance_height>` to be set via INI settings