### PR TITLE
ATC tab: remove as well as hide

### DIFF
--- a/src/probe_basic/probe_basic.py
+++ b/src/probe_basic/probe_basic.py
@@ -38,7 +38,9 @@ class ProbeBasic(VCPMainWindow):
         self.btnMdiSpace.clicked.connect(self.mdiSpace_clicked)
 
         if (0 == int(INIFILE.find("ATC", "POCKETS") or 0)):
-            self.tabWidget.setTabVisible(self.tabWidget.indexOf(self.atc_tab), False)
+            atc_tab_index = self.tabWidget.indexOf(self.atc_tab)
+            self.tabWidget.setTabVisible(atc_tab_index, False)
+            self.tabWidget.removeTab(atc_tab_index)
             
         self.vtk.setViewMachine()  # set view to machine at startup
         


### PR DESCRIPTION
this stops it showing up when scrolling tabs with a keyboard or mouse wheel