### PR TITLE
toolchange.ngc: fix missing `#<pc_tool_length> = #5403`

### DIFF
--- a/configs/atc_sim/macros_sim_inch/toolchange.ngc
+++ b/configs/atc_sim/macros_sim_inch/toolchange.ngc
@@ -128,6 +128,8 @@ o160 if [1 EQ 1]
     G43 H#<selected_tool>
 o160 endif
 
+#<pc_tool_length> = #5403
+
 (run program_coolant sub if selected to be active in settings page with value 1)
 o170 if [#<activate_programmable_coolant> EQ 1]
     (run program_coolant.ngc)

--- a/configs/atc_sim/macros_sim_metric/toolchange.ngc
+++ b/configs/atc_sim/macros_sim_metric/toolchange.ngc
@@ -128,6 +128,8 @@ o160 if [1 EQ 1]
     G43 H#<selected_tool>
 o160 endif
 
+#<pc_tool_length> = #5403
+
 (run program_coolant sub if selected to be active in settings page with value 1)
 o170 if [#<activate_programmable_coolant> EQ 1]
     (run program_coolant.ngc)

--- a/configs/probe_basic/subroutines/toolchange.ngc
+++ b/configs/probe_basic/subroutines/toolchange.ngc
@@ -128,6 +128,8 @@ o160 if [1 EQ 1]
     G43 H#<selected_tool>
 o160 endif
 
+#<pc_tool_length> = #5403
+
 (run program_coolant sub if selected to be active in settings page with value 1)
 o170 if [#<activate_programmable_coolant> EQ 1]
     (run program_coolant.ngc)

--- a/configs/probe_basic_lathe/subroutines/toolchange.ngc
+++ b/configs/probe_basic_lathe/subroutines/toolchange.ngc
@@ -128,6 +128,8 @@ o160 if [1 EQ 1]
     G43 H#<selected_tool>
 o160 endif
 
+#<pc_tool_length> = #5403
+
 (run program_coolant sub if selected to be active in settings page with value 1)
 o170 if [#<activate_programmable_coolant> EQ 1]
     (run program_coolant.ngc)


### PR DESCRIPTION
got lost during af60a5c5f0e132a4277302de45a0e64a4e1c6ddc (#85)