### PR TITLE
Program Coolant Cannon: move setting to ini rather than vcp settings

### DIFF
--- a/configs/atc_sim/custom_config.yml
+++ b/configs/atc_sim/custom_config.yml
@@ -44,12 +44,3 @@ settings:
 
   backplot.multitool-colors:
     default_value: True
-
-  programmable-coolant.active:
-    default_value: 1
-
-  programmable-coolant.spindle-to-nozzle-dist:
-    default_value: 8.0
-
-  programmable-coolant.gaugeline-to-nozzle-dist:
-    default_value: 4.0

--- a/configs/atc_sim/macros_sim/load_spindle_safety.ngc
+++ b/configs/atc_sim/macros_sim/load_spindle_safety.ngc
@@ -13,11 +13,7 @@ o<load_spindle_safety> sub
 (PRINT, o<load_spindle_safety>)
 
 #<load_spindle_tool_number> = #1 ; this is the value form the ATC tab
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 ; default to a 12 pocket ATC (matching DynATC Widget behaviour), then update based on INI settings
 #<number_of_pockets> = 12
@@ -45,15 +41,7 @@ o140 if [#<load_spindle_tool_number> EQ #<probe_tool_number>]
     S0 M5
 o140 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o150 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o150 else
-    o<load_spindle_safety> return
-o150 endif
+o<program_coolant> call
 
 o<load_spindle_safety> endsub
 

--- a/configs/atc_sim/macros_sim/load_spindle_safety_2.ngc
+++ b/configs/atc_sim/macros_sim/load_spindle_safety_2.ngc
@@ -13,11 +13,7 @@ o<load_spindle_safety_2> sub
 (PRINT, o<load_spindle_safety_2>)
 
 #<load_spindle_tool_number_2> = #1 ; this is the value form the TOOL tab
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 ; default to a 12 pocket ATC (mtoolhing DynATC Widget behaviour), then update based on INI settings
 #<number_of_pockets> = 12
@@ -45,15 +41,7 @@ o140 if [#<load_spindle_tool_number_2> EQ #<probe_tool_number>]
     S0 M5
 o140 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o150 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o150 else
-    o<load_spindle_safety_2> return
-o150 endif
+o<program_coolant> call
 
 o<load_spindle_safety_2> endsub
 

--- a/configs/atc_sim/macros_sim/m6_tool_call_atc_page.ngc
+++ b/configs/atc_sim/macros_sim/m6_tool_call_atc_page.ngc
@@ -7,11 +7,7 @@
 o<m6_tool_call_atc_page> sub
 
 #<tool_number_entry_atc_page> = #1
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 T#<tool_number_entry_atc_page> M6
 o100 if [1 EQ 1]
@@ -22,15 +18,7 @@ o110 if [#<tool_number_entry_atc_page> EQ #<probe_tool_number>]
   S0 M5
 o110 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o120 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o120 else
-    o<M6_tool_call_atc_page> return
-o120 endif
+o<program_coolant> call
 
 o<m6_tool_call_atc_page> endsub
 

--- a/configs/atc_sim/macros_sim/m6_tool_call_main_panel.ngc
+++ b/configs/atc_sim/macros_sim/m6_tool_call_main_panel.ngc
@@ -7,11 +7,7 @@
 o<m6_tool_call_main_panel> sub
 
 #<tool_number_entry_main_panel> = #1
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 T#<tool_number_entry_main_panel> M6
 
@@ -23,15 +19,7 @@ o110 if [#<tool_number_entry_main_panel> EQ #<probe_tool_number>]
   S0 M5
 o110 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o120 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o120 else
-    o<m6_tool_call_main_panel> return
-o120 endif
+o<program_coolant> call
 
 o<m6_tool_call_main_panel> endsub
 

--- a/configs/atc_sim/macros_sim/m6_tool_call_tool_page.ngc
+++ b/configs/atc_sim/macros_sim/m6_tool_call_tool_page.ngc
@@ -7,11 +7,7 @@
 o<m6_tool_call_tool_page> sub
 
 #<tool_number_entry_tool_page> = #1
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 T#<tool_number_entry_tool_page> M6
 

--- a/configs/atc_sim/macros_sim/program_coolant.ngc
+++ b/configs/atc_sim/macros_sim/program_coolant.ngc
@@ -1,9 +1,16 @@
-(author: Chris P)
-(version: 0.1)
-(date: 02/13/20)
+(author: Chris P, lwk)
+(version: 0.2)
+(date: 12/03/23)
+
+(ini settings required)
+([COOLANT_CANNON])
+(ACTIVATE = 1)
+(HORIZONTAL_SPINDLE_NOZZLE_DIST = 8)
+(VERTICAL_SPINDLE_NOZZLE_DIST = 4)
+(PC_ANGLE_OFFSET = 0)
 
 (programmable coolant subroutine for aiming the coolant nozzle)
-(settings for setup are located on probe basic setting page)
+(settings for setup are displayed on probe basic setting page)
 (in the programmable coolant constants container.)
 (calculations assume coolant nozzle is on axis b and has been homed)
 (to 0 degrees rotation aiming perpendicular to the spindle center line)
@@ -13,12 +20,37 @@
 o<program_coolant> sub
 (PRINT, o<program_coolant>)
 
-  (uses NGCGUI style arg spec)
-  (number after equals sign in comment is default value)
-  #<horizontal_spindle_nozzle_dist> = #1
-  #<vertical_spindle_nozzle_dist> = #2
-  #<pc_angle_offset> = #3
-  #<pc_tool_length> = #4
+  #<active> = 0
+  o100 if [EXISTS[#<_ini[coolant_cannon]activate>]]
+    #<active> = #<_ini[coolant_cannon]activate>
+  o100 endif
+
+  o110 if [#<active> EQ 0]
+    o110 return
+  o110 endif
+
+  o120 if [EXISTS[#<_ini[coolant_cannon]horizontal_spindle_nozzle_dist>]]
+    #<horizontal_spindle_nozzle_dist> = #<_ini[coolant_cannon]horizontal_spindle_nozzle_dist>
+  o120 else
+    (MSG, Coolant Cannon INI setting missing <HORIZONTAL_SPINDLE_NOZZLE_DIST>)
+    o120 return
+  o120 endif
+
+  o130 if [EXISTS[#<_ini[coolant_cannon]vertical_spindle_nozzle_dist>]]
+    #<vertical_spindle_nozzle_dist> = #<_ini[coolant_cannon]vertical_spindle_nozzle_dist>
+  o130 else
+    (MSG, Coolant Cannon INI setting missing <VERTICAL_SPINDLE_NOZZLE_DIST>)
+    o130 return
+  o130 endif
+
+  o140 if [EXISTS[#<_ini[coolant_cannon]pc_angle_offset>]]
+    #<pc_angle_offset> = #<_ini[coolant_cannon]pc_angle_offset>
+  o140 else
+    (MSG, Coolant Cannon INI setting missing <PC_ANGLE_OFFSET>)
+    o140 return
+  o140 endif
+
+  #<pc_tool_length> = #5403
 
   #<tool_diameter> = #5410
 

--- a/configs/atc_sim/macros_sim/toolchange.ngc
+++ b/configs/atc_sim/macros_sim/toolchange.ngc
@@ -31,12 +31,6 @@ o103 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
     #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
 o103 endif
 
-; assign the programmable coolant parameters
-#<activate_programmable_coolant> = #1 (=0)
-#<horizontal_spindle_nozzle_dist> = #2 (=0)
-#<vertical_spindle_nozzle_dist> = #3 (=0)
-#<pc_angle_offset> = #4 (=0)
-
 ; assign the variables passed by M6 change_prolog to some parameters
 #100 = #<selected_tool>
 #110 = #<tool_in_spindle>
@@ -128,13 +122,7 @@ o160 if [1 EQ 1]
     G43 H#<selected_tool>
 o160 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o170 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o170 endif
+o<program_coolant> call
 
 (PRINT, o<toolchange> endsub)
 o<toolchange> endsub [1]

--- a/configs/atc_sim/vmc_graycode_inch.ini
+++ b/configs/atc_sim/vmc_graycode_inch.ini
@@ -50,6 +50,17 @@ Z_TOOL_CLEARANCE_HEIGHT = -0.1
 # This just adjust the speed of the ATC tab Carousel GFX rotation (default if omitted is 1000ms)
 STEP_TIME = 500
 
+[COOLANT_CANNON]
+# Coolant Cannon Settings for auto coolant aiming, these are used by o<program_coolant>
+# Activate Programmable Coolant
+ACTIVATE = 1
+# Spindle centerline to nozzle centerline distance (machine units mm/inch)
+HORIZONTAL_SPINDLE_NOZZLE_DIST = 8
+# Nozzle centerline to spindle gauge line (machine units mm/inch)
+VERTICAL_SPINDLE_NOZZLE_DIST = 4
+# Nozzle angle offset (deg)
+PC_ANGLE_OFFSET = 0
+
 [RS274NGC]
 RS274NGC_STARTUP_CODE = F10 S300 G20 G17 G40 G49 G54 G64 P0.001 G80 G90 G91.1 G92.1 G94 G97 G98
 PARAMETER_FILE = vmc.var

--- a/configs/atc_sim/vmc_graycode_metric.ini
+++ b/configs/atc_sim/vmc_graycode_metric.ini
@@ -50,6 +50,17 @@ Z_TOOL_CLEARANCE_HEIGHT = -0.1
 # This just adjust the speed of the ATC tab Carousel GFX rotation (default if omitted is 1000ms)
 STEP_TIME = 500
 
+[COOLANT_CANNON]
+# Coolant Cannon Settings for auto coolant aiming, these are used by o<program_coolant>
+# Activate Programmable Coolant
+ACTIVATE = 1
+# Spindle centerline to nozzle centerline distance (machine units mm/inch)
+HORIZONTAL_SPINDLE_NOZZLE_DIST = 200
+# Nozzle centerline to spindle gauge line (machine units mm/inch)
+VERTICAL_SPINDLE_NOZZLE_DIST = 100
+# Nozzle angle offset (deg)
+PC_ANGLE_OFFSET = 0
+
 [RS274NGC]
 RS274NGC_STARTUP_CODE = F10 S300 G21 G17 G40 G49 G54 G64 P0.001 G80 G90 G91.1 G92.1 G94 G97 G98
 PARAMETER_FILE = vmc.var

--- a/configs/atc_sim/vmc_index_inch.ini
+++ b/configs/atc_sim/vmc_index_inch.ini
@@ -50,6 +50,17 @@ Z_TOOL_CLEARANCE_HEIGHT = -0.1
 # This just adjust the speed of the ATC tab Carousel GFX rotation (default if omitted is 1000ms)
 STEP_TIME = 500
 
+[COOLANT_CANNON]
+# Coolant Cannon Settings for auto coolant aiming, these are used by o<program_coolant>
+# Activate Programmable Coolant
+ACTIVATE = 1
+# Spindle centerline to nozzle centerline distance (machine units mm/inch)
+HORIZONTAL_SPINDLE_NOZZLE_DIST = 8
+# Nozzle centerline to spindle gauge line (machine units mm/inch)
+VERTICAL_SPINDLE_NOZZLE_DIST = 4
+# Nozzle angle offset (deg)
+PC_ANGLE_OFFSET = 0
+
 [RS274NGC]
 RS274NGC_STARTUP_CODE = F10 S300 G20 G17 G40 G49 G54 G64 P0.001 G80 G90 G91.1 G92.1 G94 G97 G98
 PARAMETER_FILE = vmc.var

--- a/configs/atc_sim/vmc_index_metric.ini
+++ b/configs/atc_sim/vmc_index_metric.ini
@@ -50,6 +50,17 @@ Z_TOOL_CLEARANCE_HEIGHT = -0.1
 # This just adjust the speed of the ATC tab Carousel GFX rotation (default if omitted is 1000ms)
 STEP_TIME = 500
 
+[COOLANT_CANNON]
+# Coolant Cannon Settings for auto coolant aiming, these are used by o<program_coolant>
+# Activate Programmable Coolant
+ACTIVATE = 1
+# Spindle centerline to nozzle centerline distance (machine units mm/inch)
+HORIZONTAL_SPINDLE_NOZZLE_DIST = 200
+# Nozzle centerline to spindle gauge line (machine units mm/inch)
+VERTICAL_SPINDLE_NOZZLE_DIST = 100
+# Nozzle angle offset (deg)
+PC_ANGLE_OFFSET = 0
+
 [RS274NGC]
 RS274NGC_STARTUP_CODE = F10 S300 G21 G17 G40 G49 G54 G64 P0.001 G80 G90 G91.1 G92.1 G94 G97 G98
 PARAMETER_FILE = vmc.var

--- a/configs/probe_basic/probe_basic.ini
+++ b/configs/probe_basic/probe_basic.ini
@@ -60,6 +60,17 @@ Z_TOOL_CLEARANCE_HEIGHT = -0.1
 # This just adjust the speed of the ATC tab Carousel GFX rotation (default if omitted is 1000ms)
 STEP_TIME = 500
 
+[COOLANT_CANNON]
+# Coolant Cannon Settings for auto coolant aiming, these are used by o<program_coolant>
+# Activate Programmable Coolant
+ACTIVATE = 1
+# Spindle centerline to nozzle centerline distance (machine units mm/inch)
+HORIZONTAL_SPINDLE_NOZZLE_DIST = 8
+# Nozzle centerline to spindle gauge line (machine units mm/inch)
+VERTICAL_SPINDLE_NOZZLE_DIST = 4
+# Nozzle angle offset (deg)
+PC_ANGLE_OFFSET = 0
+
 [RS274NGC]
 RS274NGC_STARTUP_CODE = F10 S300 G20 G17 G40 G49 G54 G64 P0.001 G80 G90 G91.1 G92.1 G94 G97 G98
 PARAMETER_FILE = sim.var

--- a/configs/probe_basic/subroutines/load_spindle_safety.ngc
+++ b/configs/probe_basic/subroutines/load_spindle_safety.ngc
@@ -13,11 +13,7 @@ o<load_spindle_safety> sub
 (PRINT, o<load_spindle_safety>)
 
 #<load_spindle_tool_number> = #1 ; this is the value form the ATC tab
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 ; default to a 12 pocket ATC (matching DynATC Widget behaviour), then update based on INI settings
 #<number_of_pockets> = 12
@@ -45,15 +41,7 @@ o140 if [#<load_spindle_tool_number> EQ #<probe_tool_number>]
     S0 M5
 o140 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o150 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o150 else
-    o<load_spindle_safety> return
-o150 endif
+o<program_coolant> call
 
 o<load_spindle_safety> endsub
 

--- a/configs/probe_basic/subroutines/load_spindle_safety_2.ngc
+++ b/configs/probe_basic/subroutines/load_spindle_safety_2.ngc
@@ -13,11 +13,7 @@ o<load_spindle_safety_2> sub
 (PRINT, o<load_spindle_safety_2>)
 
 #<load_spindle_tool_number_2> = #1 ; this is the value form the TOOL tab
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 ; default to a 12 pocket ATC (mtoolhing DynATC Widget behaviour), then update based on INI settings
 #<number_of_pockets> = 12
@@ -45,15 +41,7 @@ o140 if [#<load_spindle_tool_number_2> EQ #<probe_tool_number>]
     S0 M5
 o140 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o150 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o150 else
-    o<load_spindle_safety_2> return
-o150 endif
+o<program_coolant> call
 
 o<load_spindle_safety_2> endsub
 

--- a/configs/probe_basic/subroutines/m6_tool_call_atc_page.ngc
+++ b/configs/probe_basic/subroutines/m6_tool_call_atc_page.ngc
@@ -7,11 +7,7 @@
 o<m6_tool_call_atc_page> sub
 
 #<tool_number_entry_atc_page> = #1
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 T#<tool_number_entry_atc_page> M6
 o100 if [1 EQ 1]
@@ -22,15 +18,7 @@ o110 if [#<tool_number_entry_atc_page> EQ #<probe_tool_number>]
   S0 M5
 o110 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o120 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o120 else
-    o<M6_tool_call_atc_page> return
-o120 endif
+o<program_coolant> call
 
 o<m6_tool_call_atc_page> endsub
 

--- a/configs/probe_basic/subroutines/m6_tool_call_main_panel.ngc
+++ b/configs/probe_basic/subroutines/m6_tool_call_main_panel.ngc
@@ -7,11 +7,7 @@
 o<m6_tool_call_main_panel> sub
 
 #<tool_number_entry_main_panel> = #1
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 T#<tool_number_entry_main_panel> M6
 
@@ -23,15 +19,7 @@ o110 if [#<tool_number_entry_main_panel> EQ #<probe_tool_number>]
   S0 M5
 o110 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o120 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o120 else
-    o<m6_tool_call_main_panel> return
-o120 endif
+o<program_coolant> call
 
 o<m6_tool_call_main_panel> endsub
 

--- a/configs/probe_basic/subroutines/m6_tool_call_tool_page.ngc
+++ b/configs/probe_basic/subroutines/m6_tool_call_tool_page.ngc
@@ -7,11 +7,7 @@
 o<m6_tool_call_tool_page> sub
 
 #<tool_number_entry_tool_page> = #1
-#<activate_programmable_coolant> = #2
-#<horizontal_spindle_nozzle_dist> = #3
-#<vertical_spindle_nozzle_dist> = #4
-#<pc_angle_offset> = #5
-#<probe_tool_number> = #6
+#<probe_tool_number> = #2
 
 T#<tool_number_entry_tool_page> M6
 

--- a/configs/probe_basic/subroutines/program_coolant.ngc
+++ b/configs/probe_basic/subroutines/program_coolant.ngc
@@ -1,9 +1,16 @@
-(author: Chris P)
-(version: 0.1)
-(date: 02/13/20)
+(author: Chris P, lwk)
+(version: 0.2)
+(date: 12/03/23)
+
+(ini settings required)
+([COOLANT_CANNON])
+(ACTIVATE = 1)
+(HORIZONTAL_SPINDLE_NOZZLE_DIST = 8)
+(VERTICAL_SPINDLE_NOZZLE_DIST = 4)
+(PC_ANGLE_OFFSET = 0)
 
 (programmable coolant subroutine for aiming the coolant nozzle)
-(settings for setup are located on probe basic setting page)
+(settings for setup are displayed on probe basic setting page)
 (in the programmable coolant constants container.)
 (calculations assume coolant nozzle is on axis b and has been homed)
 (to 0 degrees rotation aiming perpendicular to the spindle center line)
@@ -13,12 +20,37 @@
 o<program_coolant> sub
 (PRINT, o<program_coolant>)
 
-  (uses NGCGUI style arg spec)
-  (number after equals sign in comment is default value)
-  #<horizontal_spindle_nozzle_dist> = #1
-  #<vertical_spindle_nozzle_dist> = #2
-  #<pc_angle_offset> = #3
-  #<pc_tool_length> = #4
+  #<active> = 0
+  o100 if [EXISTS[#<_ini[coolant_cannon]activate>]]
+    #<active> = #<_ini[coolant_cannon]activate>
+  o100 endif
+
+  o110 if [#<active> EQ 0]
+    o110 return
+  o110 endif
+
+  o120 if [EXISTS[#<_ini[coolant_cannon]horizontal_spindle_nozzle_dist>]]
+    #<horizontal_spindle_nozzle_dist> = #<_ini[coolant_cannon]horizontal_spindle_nozzle_dist>
+  o120 else
+    (MSG, Coolant Cannon INI setting missing <HORIZONTAL_SPINDLE_NOZZLE_DIST>)
+    o120 return
+  o120 endif
+
+  o130 if [EXISTS[#<_ini[coolant_cannon]vertical_spindle_nozzle_dist>]]
+    #<vertical_spindle_nozzle_dist> = #<_ini[coolant_cannon]vertical_spindle_nozzle_dist>
+  o130 else
+    (MSG, Coolant Cannon INI setting missing <VERTICAL_SPINDLE_NOZZLE_DIST>)
+    o130 return
+  o130 endif
+
+  o140 if [EXISTS[#<_ini[coolant_cannon]pc_angle_offset>]]
+    #<pc_angle_offset> = #<_ini[coolant_cannon]pc_angle_offset>
+  o140 else
+    (MSG, Coolant Cannon INI setting missing <PC_ANGLE_OFFSET>)
+    o140 return
+  o140 endif
+
+  #<pc_tool_length> = #5403
 
   #<tool_diameter> = #5410
 

--- a/configs/probe_basic/subroutines/toolchange.ngc
+++ b/configs/probe_basic/subroutines/toolchange.ngc
@@ -22,7 +22,7 @@ o101 if [EXISTS[#<_ini[atc]pockets>]]
     #<number_of_pockets> = #<_ini[atc]pockets>
 o101 endif
 
-#<atc_z_tool_change_height> = -3.1900
+#<atc_z_tool_change_height> = -3.9000
 o102 if [EXISTS[#<_ini[atc]z_tool_change_height>]]
     #<atc_z_tool_change_height> = #<_ini[atc]z_tool_change_height>
 o102 endif
@@ -30,12 +30,6 @@ o102 endif
 o103 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
     #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
 o103 endif
-
-; assign the programmable coolant parameters
-#<activate_programmable_coolant> = #1 (=0)
-#<horizontal_spindle_nozzle_dist> = #2 (=0)
-#<vertical_spindle_nozzle_dist> = #3 (=0)
-#<pc_angle_offset> = #4 (=0)
 
 ; assign the variables passed by M6 change_prolog to some parameters
 #100 = #<selected_tool>
@@ -128,13 +122,7 @@ o160 if [1 EQ 1]
     G43 H#<selected_tool>
 o160 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o170 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o170 endif
+o<program_coolant> call
 
 (PRINT, o<toolchange> endsub)
 o<toolchange> endsub [1]

--- a/configs/probe_basic_lathe/subroutines/program_coolant.ngc
+++ b/configs/probe_basic_lathe/subroutines/program_coolant.ngc
@@ -1,9 +1,16 @@
-(author: Chris P)
-(version: 0.1)
-(date: 02/13/20)
+(author: Chris P, lwk)
+(version: 0.2)
+(date: 12/03/23)
+
+(ini settings required)
+([COOLANT_CANNON])
+(ACTIVATE = 1)
+(HORIZONTAL_SPINDLE_NOZZLE_DIST = 8)
+(VERTICAL_SPINDLE_NOZZLE_DIST = 4)
+(PC_ANGLE_OFFSET = 0)
 
 (programmable coolant subroutine for aiming the coolant nozzle)
-(settings for setup are located on probe basic setting page)
+(settings for setup are displayed on probe basic setting page)
 (in the programmable coolant constants container.)
 (calculations assume coolant nozzle is on axis b and has been homed)
 (to 0 degrees rotation aiming perpendicular to the spindle center line)
@@ -13,12 +20,37 @@
 o<program_coolant> sub
 (PRINT, o<program_coolant>)
 
-  (uses NGCGUI style arg spec)
-  (number after equals sign in comment is default value)
-  #<horizontal_spindle_nozzle_dist> = #1
-  #<vertical_spindle_nozzle_dist> = #2
-  #<pc_angle_offset> = #3
-  #<pc_tool_length> = #4
+  #<active> = 0
+  o100 if [EXISTS[#<_ini[coolant_cannon]activate>]]
+    #<active> = #<_ini[coolant_cannon]activate>
+  o100 endif
+
+  o110 if [#<active> EQ 0]
+    o110 return
+  o110 endif
+
+  o120 if [EXISTS[#<_ini[coolant_cannon]horizontal_spindle_nozzle_dist>]]
+    #<horizontal_spindle_nozzle_dist> = #<_ini[coolant_cannon]horizontal_spindle_nozzle_dist>
+  o120 else
+    (MSG, Coolant Cannon INI setting missing <HORIZONTAL_SPINDLE_NOZZLE_DIST>)
+    o120 return
+  o120 endif
+
+  o130 if [EXISTS[#<_ini[coolant_cannon]vertical_spindle_nozzle_dist>]]
+    #<vertical_spindle_nozzle_dist> = #<_ini[coolant_cannon]vertical_spindle_nozzle_dist>
+  o130 else
+    (MSG, Coolant Cannon INI setting missing <VERTICAL_SPINDLE_NOZZLE_DIST>)
+    o130 return
+  o130 endif
+
+  o140 if [EXISTS[#<_ini[coolant_cannon]pc_angle_offset>]]
+    #<pc_angle_offset> = #<_ini[coolant_cannon]pc_angle_offset>
+  o140 else
+    (MSG, Coolant Cannon INI setting missing <PC_ANGLE_OFFSET>)
+    o140 return
+  o140 endif
+
+  #<pc_tool_length> = #5403
 
   #<tool_diameter> = #5410
 

--- a/configs/probe_basic_lathe/subroutines/toolchange.ngc
+++ b/configs/probe_basic_lathe/subroutines/toolchange.ngc
@@ -31,12 +31,6 @@ o103 if [EXISTS[#<_ini[atc]z_tool_clearance_height>]]
     #<atc_z_tool_clearance_height> = #<_ini[atc]z_tool_clearance_height>
 o103 endif
 
-; assign the programmable coolant parameters
-#<activate_programmable_coolant> = #1 (=0)
-#<horizontal_spindle_nozzle_dist> = #2 (=0)
-#<vertical_spindle_nozzle_dist> = #3 (=0)
-#<pc_angle_offset> = #4 (=0)
-
 ; assign the variables passed by M6 change_prolog to some parameters
 #100 = #<selected_tool>
 #110 = #<tool_in_spindle>
@@ -128,13 +122,7 @@ o160 if [1 EQ 1]
     G43 H#<selected_tool>
 o160 endif
 
-#<pc_tool_length> = #5403
-
-(run program_coolant sub if selected to be active in settings page with value 1)
-o170 if [#<activate_programmable_coolant> EQ 1]
-    (run program_coolant.ngc)
-    o<program_coolant> call [#<horizontal_spindle_nozzle_dist>][#<vertical_spindle_nozzle_dist>][#<pc_angle_offset>][#<pc_tool_length>]
-o170 endif
+o<program_coolant> call
 
 (PRINT, o<toolchange> endsub)
 o<toolchange> endsub [1]

--- a/src/probe_basic/probe_basic.py
+++ b/src/probe_basic/probe_basic.py
@@ -53,6 +53,7 @@ class ProbeBasic(VCPMainWindow):
             self.spindle_rpm_source_widget.setCurrentIndex(self.spindle_encoder_rpm_button.property('page'))
         
         self.load_user_tabs()
+        self.load_programmable_coolant_cannon_settings()
 
     def load_user_tabs(self):
         self.user_tab_modules = {}
@@ -87,6 +88,12 @@ class ProbeBasic(VCPMainWindow):
         if sidebar_loaded == False:
             self.user_sb_tab.hide()
             self.plot_tab.setStyleSheet(self.user_sb_tab.styleSheet())
+
+    def load_programmable_coolant_cannon_settings(self):
+        self.activate_programmable_coolant.setValue(int(INIFILE.find("COOLANT_CANNON", "ACTIVATE")) or 0)
+        self.horizontal_spindle_nozzle_dist.setValue(int(INIFILE.find("COOLANT_CANNON", "HORIZONTAL_SPINDLE_NOZZLE_DIST")) or 0)
+        self.vertical_spindle_nozzle_dist.setValue(int(INIFILE.find("COOLANT_CANNON", "VERTICAL_SPINDLE_NOZZLE_DIST")) or 0)
+        self.pc_angle_offset.setValue(int(INIFILE.find("COOLANT_CANNON", "PC_ANGLE_OFFSET")) or 0)
 
     @Slot(QAbstractButton)
     def on_probetabGroup_buttonClicked(self, button):

--- a/src/probe_basic/probe_basic.ui
+++ b/src/probe_basic/probe_basic.ui
@@ -22307,6 +22307,9 @@ color: white;
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
                  <property name="placeholderText">
                   <string>0</string>
                  </property>
@@ -22393,6 +22396,9 @@ color: white;
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
                  </property>
                  <property name="placeholderText">
                   <string>0.0000</string>
@@ -22481,6 +22487,9 @@ color: white;
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
                  <property name="placeholderText">
                   <string>0.0000</string>
                  </property>
@@ -22567,6 +22576,9 @@ color: white;
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
                  </property>
                  <property name="placeholderText">
                   <string>0.0</string>


### PR DESCRIPTION
This allows if to work correctly with "M6" remap tool changes as well as "Load Spindle" and "M6 G43" button calls at the sacrifice of being able to update the configuration in the GUI