### PR TITLE
Update tool_touch_off.ngc no G59.3

### DIFF
--- a/configs/probe_basic/subroutines/tool_touch_off.ngc
+++ b/configs/probe_basic/subroutines/tool_touch_off.ngc
@@ -1,7 +1,5 @@
 o<tool_touch_off> sub
 
-; NOTE this routine used G59.3, and this needs to be set to 0,0,0 for everything to work correctly
-
 #<fast_probe_fr> = #1    (set from probe screen fast probe feed rate)
 #<slow_probe_fr> = #2    (set from probe screen slow probe feedrate)
 #<z_max_travel> = #3    (max z distance the tool travels before erroring out if not contact is made)
@@ -14,16 +12,12 @@ o<tool_touch_off> sub
 
 G92.1    (Cancel G92 offset)
 
-#<workspace_z> = #5220
-
 #<tool_touch_x_coords> = #5181
 #<tool_touch_y_coords> = #5182
 #<tool_touch_z_coords> = #5183
 
 #<tool_radius_offset> = [#<tool_diameter> / 2]
 #<offset_probing_position> = [#<tool_touch_x_coords> - #<tool_radius_offset>]
-
-G59.3
 
 o100 if [#<tool_diameter_offset_mode> EQ 1]
     #<tool_touch_x_coords> = #<offset_probing_position>
@@ -37,6 +31,7 @@ G90    (set absolute coordinates)
 G53 G0 Z0    (move to z0 home position)
 G53 G0 X#<tool_touch_x_coords> Y#<tool_touch_y_coords>
 G53 G0 Z#<tool_touch_z_coords>
+#<offset_z> = #5422         ;Stores the offset of the current Z coordinate.
 
 G91
 F #<fast_probe_fr>
@@ -74,27 +69,10 @@ G90    (set absolute coordinates)
 G53 G0 Z0 (Send Spindle to home zero position)
 
 (define new tool length offset parameters)
-#<new_tool_length_offset> = [ABS[#<spindle_zero_height> + #5063]]
+#<new_tool_length_offset> = [ABS[#<spindle_zero_height> + #5063 - #<offset_z>]]
 
 G10 L1 P #5400 Z [#<new_tool_length_offset>]  (5400 = tool number)
 
-o160 if [#<workspace_z> EQ 1]
-    G54
-o160 else if [#<workspace_z> EQ 2]
-    G55
-o160 else if [#<workspace_z> EQ 3]
-    G56
-o160 else if [#<workspace_z> EQ 4]
-    G57
-o160 else if [#<workspace_z> EQ 5]
-    G58
-o160 else if [#<workspace_z> EQ 6]
-    G59
-o160 else if [#<workspace_z> EQ 7]
-    G59.1
-o160 else if [#<workspace_z> EQ 8]
-    G59.2
-o160 endif
 
 T #5400 G43  H #5400    (enable tool length offset)
 


### PR DESCRIPTION
Changed the routine so that it no longer relies on G59.3. 
The routine now works with the current coordinate system without changing it.

"offset_s" saves the Z position when starting the measurement. The value is processed when calculating the length and the correct length is obtained.
It is not relevant whether the measurement is started at Z0 or lower.